### PR TITLE
Feat/email validation pages in frontend

### DIFF
--- a/src/navigation/StackNavigation.tsx
+++ b/src/navigation/StackNavigation.tsx
@@ -7,6 +7,8 @@ import { Login } from '../pages/Login';
 import { Signup } from '../pages/Signup';
 import { BottomNavigation } from './BottomNavigation';
 import { MapProvider } from '@src/context/MapProvider';
+import { EmailValidationView } from '../pages/EmailValidationView';
+import { NewCodeView } from '../pages/NewCodeView';
 
 const Stack = createStackNavigator();
 export const StackNavigation = () => {
@@ -23,6 +25,8 @@ export const StackNavigation = () => {
         <Stack.Screen name='Combat' component={CombatView} />
         <Stack.Screen name='Login' component={Login} />
         <Stack.Screen name='Signup' component={Signup} />
+        <Stack.Screen name='EmailValidation' component={EmailValidationView} />
+        <Stack.Screen name='NewCode' component={NewCodeView} />
         {/* Views that includes the bottom tabs navigation */}
         <Stack.Screen name='Application' component={BottomNavigation} />
       </Stack.Navigator>

--- a/src/pages/EmailValidationView.tsx
+++ b/src/pages/EmailValidationView.tsx
@@ -44,7 +44,7 @@ export const EmailValidationView = ({
   return (
     <View style={Styles.container}>
       <View style={Styles.header}>
-        <Text style={Styles.headerTitle}>INSERT YOUR CODE</Text>
+        <Text style={Styles.headerTitle}>Validate account</Text>
       </View>
       <View style={Styles.footer}>
         <View style={Styles.form}>

--- a/src/pages/EmailValidationView.tsx
+++ b/src/pages/EmailValidationView.tsx
@@ -1,62 +1,50 @@
 import React from 'react';
 import { Pressable, StyleSheet, Text, TextInput, View } from 'react-native';
 import { useFormik } from 'formik';
-import * as Yup from 'yup';
 import { NavigationProp } from '@react-navigation/core';
 import { CustomButton } from '../components/CustomButton';
-import { signupRequest } from '../services/user.services';
+import { codeValidationRequest } from '../services/user.services';
 import { useToastAlert } from '../hooks/useToastAlert';
 
-interface SignupProps {
+interface EmailValidationViewProps {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   navigation: NavigationProp<any, any>;
 }
 
-export const Signup = ({ navigation }: SignupProps) => {
+export const EmailValidationView = ({
+  navigation
+}: EmailValidationViewProps) => {
   const { showSuccessToast, showErrorToast } = useToastAlert();
 
   const redirectToLogin = () => {
     navigation.navigate('Login');
   };
-  const redirectToEmailValidation = () => {
-    navigation.navigate('EmailValidation');
+  const redirectToNewCode = () => {
+    navigation.navigate('NewCode');
   };
 
   const formik = useFormik({
     initialValues: {
       email: '',
-      username: '',
-      password: ''
+      code: ''
     },
-    validationSchema: Yup.object({
-      email: Yup.string().email().required(),
-      username: Yup.string().required(),
-      password: Yup.string()
-        .matches(
-          /^(?=.*[A-Z])(?=.*[a-z])(?=.*\d)(?=.*[)(;.,\][}{_=@$!¡#%*?¿&^+-/<>|~'"])[A-Za-z\d)(;.,\][}{_=@$!¡#%*?¿&^+-/<>|~'"]{8,}$/,
-          'Password must be at least 8 characters long, contain at least one uppercase letter, one lowercase letter, one number, and one special character'
-        )
-        .required()
-    }),
-
     onSubmit: async (values) => {
-      const [response, error] = await signupRequest(
+      const [response, error] = await codeValidationRequest(
         values.email,
-        values.username,
-        values.password
+        values.code
       );
       if (error && response?.message) {
         showErrorToast(response?.message);
       } else {
-        showSuccessToast('User created succesfully, now confirm your Email');
-        redirectToEmailValidation();
+        showSuccessToast(response?.message);
+        redirectToLogin();
       }
     }
   });
   return (
     <View style={Styles.container}>
       <View style={Styles.header}>
-        <Text style={Styles.headerTitle}>SIGNUP</Text>
+        <Text style={Styles.headerTitle}>INSERT YOUR CODE</Text>
       </View>
       <View style={Styles.footer}>
         <View style={Styles.form}>
@@ -68,44 +56,24 @@ export const Signup = ({ navigation }: SignupProps) => {
             value={formik.values.email}
             onChangeText={formik.handleChange('email')}
           />
-          {/* Shows the email validation error if exists */}
-          {formik.errors.email && (
-            <Text style={Styles.formError}>*{formik.errors.email}</Text>
-          )}
           <TextInput
             style={{ ...Styles.formField, marginTop: 8 }}
             placeholderTextColor={'#9C9C9C'}
-            placeholder='Username'
+            placeholder='Your Code'
             autoCapitalize='none'
-            value={formik.values.username}
-            onChangeText={formik.handleChange('username')}
+            value={formik.values.code}
+            onChangeText={formik.handleChange('code')}
           />
-          {/* Shows the username validation error if exists */}
-          {formik.errors.username && (
-            <Text style={Styles.formError}>*{formik.errors.username}</Text>
-          )}
-          <TextInput
-            style={{ ...Styles.formField, marginTop: 8 }}
-            placeholderTextColor={'#9C9C9C'}
-            placeholder='********'
-            secureTextEntry={true}
-            value={formik.values.password}
-            onChangeText={formik.handleChange('password')}
-          />
-          {/* Shows the password validation error if exists */}
-          {formik.errors.password && (
-            <Text style={Styles.formError}>*{formik.errors.password}</Text>
-          )}
           <CustomButton
-            title='Create account'
+            title='Validate'
             type='primary'
             callback={formik.handleSubmit}
           />
         </View>
         <View style={Styles.redirect}>
-          <Pressable onPress={redirectToLogin}>
+          <Pressable onPress={redirectToNewCode}>
             <Text style={Styles.redirectText}>
-              Already have an account? Login
+              Lost your code? Click here and get another one!
             </Text>
           </Pressable>
         </View>
@@ -147,12 +115,6 @@ const Styles = StyleSheet.create({
     backgroundColor: '#ECECEC',
     color: '#6C6C6C',
     paddingHorizontal: 16
-  },
-  formError: {
-    color: '#ED4A5F',
-    fontSize: 12,
-    fontWeight: 'bold',
-    textTransform: 'capitalize'
   },
   redirect: {
     alignSelf: 'center',

--- a/src/pages/EmailValidationView.tsx
+++ b/src/pages/EmailValidationView.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Pressable, StyleSheet, Text, TextInput, View } from 'react-native';
 import { useFormik } from 'formik';
-import { NavigationProp } from '@react-navigation/core';
+import { NavigationProp, RouteProp } from '@react-navigation/core';
 import { CustomButton } from '../components/CustomButton';
 import { codeValidationRequest } from '../services/user.services';
 import { useToastAlert } from '../hooks/useToastAlert';
@@ -9,23 +9,30 @@ import { useToastAlert } from '../hooks/useToastAlert';
 interface EmailValidationViewProps {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   navigation: NavigationProp<any, any>;
+  route: RouteProp<{ params: { email: string } }, 'params'>;
 }
 
 export const EmailValidationView = ({
-  navigation
+  navigation,
+  route
 }: EmailValidationViewProps) => {
   const { showSuccessToast, showErrorToast } = useToastAlert();
 
   const redirectToLogin = () => {
     navigation.navigate('Login');
   };
+
   const redirectToNewCode = () => {
-    navigation.navigate('NewCode');
+    // Redirect to the validation screen and pass the email as a param
+    navigation.navigate('NewCode', { email: formik.values.email });
   };
+
+  // Try to get the email from the params
+  const { email } = route.params;
 
   const formik = useFormik({
     initialValues: {
-      email: '',
+      email: email || '',
       code: ''
     },
     onSubmit: async (values) => {

--- a/src/pages/EmailValidationView.tsx
+++ b/src/pages/EmailValidationView.tsx
@@ -28,7 +28,7 @@ export const EmailValidationView = ({
   };
 
   // Try to get the email from the params
-  const { email } = route.params;
+  const { email } = route.params || {};
 
   const formik = useFormik({
     initialValues: {

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -27,6 +27,9 @@ export const Login = ({ navigation }: LoginProps) => {
   const redirectToSignup = () => {
     navigation.navigate('Signup');
   };
+  const redirectToEmailVal = () => {
+    navigation.navigate('EmailValidation');
+  };
 
   const formik = useFormik({
     initialValues: {
@@ -81,6 +84,11 @@ export const Login = ({ navigation }: LoginProps) => {
             title='Login'
             type='primary'
             callback={formik.handleSubmit}
+          />
+          <CustomButton
+            title='Validate account'
+            type='primary'
+            callback={redirectToEmailVal}
           />
         </View>
         <View style={Styles.redirect}>

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -28,7 +28,7 @@ export const Login = ({ navigation }: LoginProps) => {
     navigation.navigate('Signup');
   };
   const redirectToEmailVal = () => {
-    navigation.navigate('EmailValidation');
+    navigation.navigate('EmailValidation', { email: formik.values.email });
   };
 
   const formik = useFormik({

--- a/src/pages/NewCodeView.tsx
+++ b/src/pages/NewCodeView.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Pressable, StyleSheet, Text, TextInput, View } from 'react-native';
 import { useFormik } from 'formik';
-import { NavigationProp } from '@react-navigation/core';
+import { NavigationProp, RouteProp } from '@react-navigation/core';
 import { CustomButton } from '../components/CustomButton';
 import { newCodeRequest } from '../services/user.services';
 import { useToastAlert } from '../hooks/useToastAlert';
@@ -9,18 +9,22 @@ import { useToastAlert } from '../hooks/useToastAlert';
 interface NewCodeViewProps {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   navigation: NavigationProp<any, any>;
+  route: RouteProp<{ params: { email: string } }, 'params'>;
 }
 
-export const NewCodeView = ({ navigation }: NewCodeViewProps) => {
+export const NewCodeView = ({ navigation, route }: NewCodeViewProps) => {
   const { showSuccessToast, showErrorToast } = useToastAlert();
 
   const redirectToEmailVal = () => {
     navigation.navigate('EmailValidation');
   };
 
+  // Try to get the email from the params
+  const { email } = route.params;
+
   const formik = useFormik({
     initialValues: {
-      email: ''
+      email: email || ''
     },
     // todo
     onSubmit: async (values) => {

--- a/src/pages/NewCodeView.tsx
+++ b/src/pages/NewCodeView.tsx
@@ -36,7 +36,7 @@ export const NewCodeView = ({ navigation }: NewCodeViewProps) => {
   return (
     <View style={Styles.container}>
       <View style={Styles.header}>
-        <Text style={Styles.headerTitle}>INSERT YOUR EMAIL</Text>
+        <Text style={Styles.headerTitle}>REQUEST A NEW CODE</Text>
       </View>
       <View style={Styles.footer}>
         <View style={Styles.form}>

--- a/src/pages/NewCodeView.tsx
+++ b/src/pages/NewCodeView.tsx
@@ -14,7 +14,7 @@ interface NewCodeViewProps {
 export const NewCodeView = ({ navigation }: NewCodeViewProps) => {
   const { showSuccessToast, showErrorToast } = useToastAlert();
 
-  const redirectToLogin = () => {
+  const redirectToEmailVal = () => {
     navigation.navigate('EmailValidation');
   };
 
@@ -29,7 +29,7 @@ export const NewCodeView = ({ navigation }: NewCodeViewProps) => {
         showErrorToast(response?.message);
       } else {
         showSuccessToast(response?.message);
-        redirectToLogin();
+        redirectToEmailVal();
       }
     }
   });
@@ -55,7 +55,7 @@ export const NewCodeView = ({ navigation }: NewCodeViewProps) => {
           />
         </View>
         <View style={Styles.redirect}>
-          <Pressable onPress={redirectToLogin}>
+          <Pressable onPress={redirectToEmailVal}>
             <Text style={Styles.redirectText}>
               Found your code? Click here and validate it!
             </Text>

--- a/src/pages/NewCodeView.tsx
+++ b/src/pages/NewCodeView.tsx
@@ -1,0 +1,112 @@
+import React from 'react';
+import { Pressable, StyleSheet, Text, TextInput, View } from 'react-native';
+import { useFormik } from 'formik';
+import { NavigationProp } from '@react-navigation/core';
+import { CustomButton } from '../components/CustomButton';
+import { newCodeRequest } from '../services/user.services';
+import { useToastAlert } from '../hooks/useToastAlert';
+
+interface NewCodeViewProps {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  navigation: NavigationProp<any, any>;
+}
+
+export const NewCodeView = ({ navigation }: NewCodeViewProps) => {
+  const { showSuccessToast, showErrorToast } = useToastAlert();
+
+  const redirectToLogin = () => {
+    navigation.navigate('EmailValidation');
+  };
+
+  const formik = useFormik({
+    initialValues: {
+      email: ''
+    },
+    // todo
+    onSubmit: async (values) => {
+      const [response, error] = await newCodeRequest(values.email);
+      if (error && response?.message) {
+        showErrorToast(response?.message);
+      } else {
+        showSuccessToast(response?.message);
+        redirectToLogin();
+      }
+    }
+  });
+  return (
+    <View style={Styles.container}>
+      <View style={Styles.header}>
+        <Text style={Styles.headerTitle}>INSERT YOUR EMAIL</Text>
+      </View>
+      <View style={Styles.footer}>
+        <View style={Styles.form}>
+          <TextInput
+            style={Styles.formField}
+            placeholderTextColor={'#9C9C9C'}
+            placeholder='Email'
+            autoCapitalize='none'
+            value={formik.values.email}
+            onChangeText={formik.handleChange('email')}
+          />
+          <CustomButton
+            title='Send me a new code!'
+            type='primary'
+            callback={formik.handleSubmit}
+          />
+        </View>
+        <View style={Styles.redirect}>
+          <Pressable onPress={redirectToLogin}>
+            <Text style={Styles.redirectText}>
+              Found your code? Click here and validate it!
+            </Text>
+          </Pressable>
+        </View>
+      </View>
+    </View>
+  );
+};
+
+const Styles = StyleSheet.create({
+  container: {
+    flex: 1
+  },
+  header: {
+    alignContent: 'center',
+    backgroundColor: '#ED4A5F',
+    flex: 1,
+    justifyContent: 'flex-end'
+  },
+  headerTitle: {
+    color: '#fff',
+    fontSize: 28,
+    fontWeight: 'bold',
+    marginBottom: 96,
+    textAlign: 'center',
+    textTransform: 'uppercase'
+  },
+  footer: {
+    backgroundColor: '#fff',
+    flex: 1
+  },
+  form: {
+    alignSelf: 'center',
+    backgroundColor: '#fff',
+    marginTop: -64,
+    padding: 12,
+    width: '80%'
+  },
+  formField: {
+    backgroundColor: '#ECECEC',
+    color: '#6C6C6C',
+    paddingHorizontal: 16
+  },
+  redirect: {
+    alignSelf: 'center',
+    flex: 1,
+    justifyContent: 'flex-end',
+    padding: 16
+  },
+  redirectText: {
+    color: '#5C5C5C'
+  }
+});

--- a/src/pages/Signup.tsx
+++ b/src/pages/Signup.tsx
@@ -19,7 +19,9 @@ export const Signup = ({ navigation }: SignupProps) => {
     navigation.navigate('Login');
   };
   const redirectToEmailValidation = () => {
-    navigation.navigate('EmailValidation');
+    // Redirect to the validation screen and pass the email as a param
+    // to auto fill the input
+    navigation.navigate('EmailValidation', { email: formik.values.email });
   };
 
   const formik = useFormik({

--- a/src/services/user.services.ts
+++ b/src/services/user.services.ts
@@ -26,3 +26,42 @@ export const signupRequest = async (
     return [null, true];
   }
 };
+
+// TODO
+export const codeValidationRequest = async (
+  email: string,
+  validationCode: string
+): Promise<[any, boolean]> => {
+  try {
+    const response = await Axios.post(`${API_URL}/code_validation`, {
+      email,
+      validationCode
+    });
+    return [response.data, false];
+  } catch (error) {
+    // Return the custom error message if exists
+    if (Axios.isAxiosError(error)) {
+      return [error.response?.data, true];
+    }
+
+    return [null, true];
+  }
+};
+
+export const newCodeRequest = async (
+  email: string
+): Promise<[any, boolean]> => {
+  try {
+    const response = await Axios.post(`${API_URL}/new_code`, {
+      email
+    });
+    return [response.data, false];
+  } catch (error) {
+    // Return the custom error message if exists
+    if (Axios.isAxiosError(error)) {
+      return [error.response?.data, true];
+    }
+
+    return [null, true];
+  }
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,7 @@
     "skipLibCheck": true,                                 /* Skip type checking all .d.ts files. */
     "baseUrl": ".",
     "paths": {
-      "@src/*": ["src/*"]
+      "@src/*": ["src/*"],
       "@assets/*": ["assets/*"]
     }
   }


### PR DESCRIPTION
You can try this pr, along with the (https://github.com/PedroChaparro/loomies-backend/pull/62) feat/email-validation backend branch, or if it's already approved, you can try with the dev branch.

There are two new views:
- Validate account: It is used to validate the code that is sent by email. It has a space for the email and for the code.
![image](https://user-images.githubusercontent.com/62608580/225164044-19d4d3e4-1c72-42c0-a1e5-73525ab78a85.png)

- Send new code: It is used to send a new mail to the mail. It has a space for mail.
![image](https://user-images.githubusercontent.com/62608580/225164069-9fa17f4c-f63c-4533-9c10-568822d08bef.png)

In the different views, links are offered to go to different points as needed, for example, if someone is already sign up and is in login page, but their code is not validated, they can request to do so by clicking on validate account.