### PR TITLE
Fix: Fix Caught Loomies Card components

### DIFF
--- a/src/components/CaughtLoomiesGrid/CaughtLoomieCard.tsx
+++ b/src/components/CaughtLoomiesGrid/CaughtLoomieCard.tsx
@@ -1,17 +1,16 @@
 import { TCaughtLoomieToRender } from '@src/types/types';
 import { colors, images } from '@src/utils/utils';
 import React from 'react';
-import { Image, StyleSheet, Text, View } from 'react-native';
+import { Image, Pressable, StyleSheet, Text, View } from 'react-native';
 import { Grayscale } from 'react-native-color-matrix-image-filters';
-import { TouchableWithoutFeedback } from 'react-native-gesture-handler';
 import MaterialCommunityIcon from 'react-native-vector-icons/MaterialCommunityIcons';
 
 interface IProps {
   loomie: TCaughtLoomieToRender;
   markIfBusy: boolean;
   markIfSelected: boolean;
-  // eslint-disable-next-line no-unused-vars, @typescript-eslint/no-explicit-any
-  cardCallback: (a?: any) => void;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  cardCallback(_a: any): void;
 }
 
 export const LoomieCard = ({
@@ -55,7 +54,7 @@ export const LoomieCard = ({
 
   return (
     <View style={Styles.card}>
-      <TouchableWithoutFeedback onPress={() => cardCallback(loomie._id)}>
+      <Pressable onPress={() => cardCallback(loomie._id)}>
         {/* Inner spacing to create a gap between the elements */}
         <View style={Styles.spacing}>
           <View
@@ -108,7 +107,7 @@ export const LoomieCard = ({
             </View>
           </View>
         </View>
-      </TouchableWithoutFeedback>
+      </Pressable>
     </View>
   );
 };

--- a/src/components/CaughtLoomiesGrid/CaughtLoomieCard.tsx
+++ b/src/components/CaughtLoomiesGrid/CaughtLoomieCard.tsx
@@ -1,4 +1,4 @@
-import { TCaughtLoomiesWithTeam } from '@src/types/types';
+import { TCaughtLoomieToRender } from '@src/types/types';
 import { colors, images } from '@src/utils/utils';
 import React from 'react';
 import { Image, StyleSheet, Text, View } from 'react-native';
@@ -7,9 +7,9 @@ import { TouchableWithoutFeedback } from 'react-native-gesture-handler';
 import MaterialCommunityIcon from 'react-native-vector-icons/MaterialCommunityIcons';
 
 interface IProps {
-  loomie: TCaughtLoomiesWithTeam;
+  loomie: TCaughtLoomieToRender;
   markIfBusy: boolean;
-  markIfInTeam: boolean;
+  markIfSelected: boolean;
   // eslint-disable-next-line no-unused-vars, @typescript-eslint/no-explicit-any
   cardCallback: (a?: any) => void;
 }
@@ -17,7 +17,7 @@ interface IProps {
 export const LoomieCard = ({
   loomie,
   markIfBusy,
-  markIfInTeam,
+  markIfSelected,
   cardCallback
 }: IProps) => {
   // Get the color from the first type
@@ -30,7 +30,7 @@ export const LoomieCard = ({
 
   // Function to render a border if the loomie is part of the user's team
   const renderBorder = () => {
-    if (markIfInTeam && loomie.is_in_team) {
+    if (markIfSelected && loomie.is_selected) {
       return {
         borderColor: '#ED4A5F'
       };

--- a/src/components/CaughtLoomiesGrid/LoomiesGrid.tsx
+++ b/src/components/CaughtLoomiesGrid/LoomiesGrid.tsx
@@ -1,12 +1,12 @@
-import { TCaughtLoomiesWithTeam } from '@src/types/types';
+import { TCaughtLoomieToRender } from '@src/types/types';
 import React from 'react';
 import { FlatList, View } from 'react-native';
 import { LoomieCard } from './CaughtLoomieCard';
 
 interface IProps {
-  loomies: Array<TCaughtLoomiesWithTeam>;
+  loomies: Array<TCaughtLoomieToRender>;
   markBusyLoomies: boolean;
-  markTeamLoomies: boolean;
+  markSelectedLoomies: boolean;
   // eslint-disable-next-line no-unused-vars, @typescript-eslint/no-explicit-any
   elementsCallback: (a?: any) => void;
   listHeaderComponent?: React.ReactElement;
@@ -15,7 +15,7 @@ interface IProps {
 export const LoomiesGrid = ({
   loomies,
   markBusyLoomies,
-  markTeamLoomies,
+  markSelectedLoomies,
   elementsCallback,
   listHeaderComponent
 }: IProps) => {
@@ -35,7 +35,7 @@ export const LoomiesGrid = ({
           <LoomieCard
             loomie={item}
             markIfBusy={markBusyLoomies}
-            markIfInTeam={markTeamLoomies}
+            markIfSelected={markSelectedLoomies}
             cardCallback={elementsCallback}
           />
         );

--- a/src/components/Modals/FuseLoomiesModal.tsx
+++ b/src/components/Modals/FuseLoomiesModal.tsx
@@ -1,0 +1,95 @@
+import {
+  getLoomieTeamService,
+  getLoomiesRequest
+} from '@src/services/user.services';
+import { TCaughtLoomieToRender, TCaughtLoomies } from '@src/types/types';
+import React, { useCallback, useEffect, useState } from 'react';
+import { Text, View } from 'react-native';
+import Modal from 'react-native-modal';
+import { LoomiesGrid } from '../CaughtLoomiesGrid/LoomiesGrid';
+
+interface IProps {
+  selectedLoomie: TCaughtLoomieToRender;
+  isVisible: boolean;
+  toggleVisibilityCallback: () => void;
+}
+
+export const FuseLoomiesModal = ({
+  selectedLoomie,
+  isVisible,
+  toggleVisibilityCallback
+}: IProps) => {
+  const [team, setTeam] = useState<string[]>([]);
+  const [loomies, setLoomies] = useState<TCaughtLoomieToRender[]>();
+
+  // Request to obtain the loomies
+  const fetchLoomies = async () => {
+    const [response, err] = await getLoomiesRequest();
+    if (err) return;
+
+    const loomies: TCaughtLoomies[] = response.loomies;
+
+    const loomiesWithTeamProperty = loomies.map((loomie) => {
+      const isTeamLoomie = team.includes(loomie._id);
+
+      return {
+        ...loomie,
+        is_in_team: isTeamLoomie,
+        is_selected: isTeamLoomie
+      };
+    });
+
+    // Filter loomies to show only the ones that can be fused
+    const fuseCandidates = loomiesWithTeamProperty.filter((loomie) => {
+      return (
+        loomie._id !== selectedLoomie._id &&
+        loomie.serial === selectedLoomie.serial &&
+        !loomie.is_busy
+      );
+    });
+
+    setLoomies(fuseCandidates);
+  };
+
+  // Request to obtain the team
+  const fetchLoomieTeam = async () => {
+    const [response, err] = await getLoomieTeamService();
+    if (err) return;
+    const team: Array<TCaughtLoomieToRender> = response.team;
+    setTeam(team.map((loomie) => loomie._id));
+  };
+
+  // First, get the team, then get the loomies
+  useEffect(() => {
+    fetchLoomieTeam();
+  }, []);
+
+  useEffect(() => {
+    fetchLoomies();
+    console.log('Loomies were fetched');
+  }, [team]);
+
+  const handleLoomiePress = useCallback((loomieId: string) => {
+    console.log('Loomie pressed: ', loomieId);
+  }, []);
+
+  if (!loomies) return <Text>Loading...</Text>;
+
+  return (
+    <Modal
+      isVisible={isVisible}
+      onBackdropPress={toggleVisibilityCallback}
+      onBackButtonPress={toggleVisibilityCallback}
+      style={{ backgroundColor: 'red' }}
+    >
+      <View style={{ flex: 1 }}>
+        <LoomiesGrid
+          loomies={loomies}
+          markBusyLoomies={false}
+          markSelectedLoomies={true}
+          elementsCallback={handleLoomiePress}
+        />
+      </View>
+    </Modal>
+  );
+};

--- a/src/pages/LoomieDetails.tsx
+++ b/src/pages/LoomieDetails.tsx
@@ -1,5 +1,5 @@
 import { RouteProp, useFocusEffect } from '@react-navigation/core';
-import { TCaughtLoomiesWithTeam } from '@src/types/types';
+import { TCaughtLoomieToRender } from '@src/types/types';
 import { StyleSheet, Text, View } from 'react-native';
 import React, { useContext, useEffect, useState } from 'react';
 import { colors } from '@src/utils/utils';
@@ -10,11 +10,11 @@ import { BabylonContext } from '@src/context/BabylonProvider';
 import { Loomie3DModelPreview } from '@src/components/LoomieDetails/Loomie3DModelPreview';
 
 interface IProps {
-  route?: RouteProp<{ params: { loomie: TCaughtLoomiesWithTeam } }, 'params'>;
+  route?: RouteProp<{ params: { loomie: TCaughtLoomieToRender } }, 'params'>;
 }
 
 export const LoomieDetails = ({ route }: IProps) => {
-  const [loomie, setLoomie] = useState<TCaughtLoomiesWithTeam | null>(null);
+  const [loomie, setLoomie] = useState<TCaughtLoomieToRender | null>(null);
   const { showSceneDetails, showSceneNone } = useContext(BabylonContext);
 
   useEffect(() => {

--- a/src/pages/LoomieDetails.tsx
+++ b/src/pages/LoomieDetails.tsx
@@ -1,6 +1,6 @@
 import { RouteProp, useFocusEffect } from '@react-navigation/core';
 import { TCaughtLoomieToRender } from '@src/types/types';
-import { StyleSheet, Text, View } from 'react-native';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
 import React, { useContext, useEffect, useState } from 'react';
 import { colors } from '@src/utils/utils';
 import { LoomieLevelBar } from '@src/components/LoomieDetails/LoomieLevelBar';
@@ -8,14 +8,21 @@ import { LoomieStatsTable } from '@src/components/LoomieDetails/LoomieStatsTable
 import { LoomieTypes } from '@src/components/LoomieDetails/LoomieTypes';
 import { BabylonContext } from '@src/context/BabylonProvider';
 import { Loomie3DModelPreview } from '@src/components/LoomieDetails/Loomie3DModelPreview';
+import MaterialCommunityIcon from 'react-native-vector-icons/MaterialCommunityIcons';
+import { FuseLoomiesModal } from '@src/components/Modals/FuseLoomiesModal';
 
 interface IProps {
   route?: RouteProp<{ params: { loomie: TCaughtLoomieToRender } }, 'params'>;
 }
 
 export const LoomieDetails = ({ route }: IProps) => {
+  const [showFuseModal, setShowFuseModal] = useState(false);
   const [loomie, setLoomie] = useState<TCaughtLoomieToRender | null>(null);
   const { showSceneDetails, showSceneNone } = useContext(BabylonContext);
+
+  const toggleFuseModalVisibility = () => {
+    setShowFuseModal(!showFuseModal);
+  };
 
   useEffect(() => {
     // Try to get the loomie from the route params
@@ -36,36 +43,64 @@ export const LoomieDetails = ({ route }: IProps) => {
   const typeColor = colors[mainColor];
 
   return (
-    <View style={{ ...Styles.background, backgroundColor: typeColor }}>
-      <View style={Styles.scenario}>
-        <Loomie3DModelPreview serial={loomie.serial} color={typeColor} />
-      </View>
-      <View style={Styles.information}>
-        <View style={Styles.row}>
-          <Text style={Styles.loomieName}>{loomie.name}</Text>
-        </View>
-        <View style={Styles.row}>
-          <LoomieTypes types={loomie.types} />
-        </View>
-        <LoomieLevelBar
-          level={loomie.level}
-          experience={loomie.experience}
-          color={typeColor}
+    <>
+      {showFuseModal && (
+        <FuseLoomiesModal
+          isVisible={showFuseModal}
+          selectedLoomie={loomie}
+          toggleVisibilityCallback={toggleFuseModalVisibility}
         />
-        <LoomieStatsTable
-          level={loomie.level}
-          hp={loomie.hp}
-          defense={loomie.defense}
-          attack={loomie.attack}
-        />
+      )}
+      <View style={{ ...Styles.background, backgroundColor: typeColor }}>
+        <Pressable
+          style={Styles.fuseFloatingButton}
+          onPress={toggleFuseModalVisibility}
+        >
+          <MaterialCommunityIcon name='merge' color={'white'} size={32} />
+        </Pressable>
+        <View style={Styles.scenario}>
+          <Loomie3DModelPreview serial={loomie.serial} color={typeColor} />
+        </View>
+        <View style={Styles.information}>
+          <View style={Styles.row}>
+            <Text style={Styles.loomieName}>{loomie.name}</Text>
+          </View>
+          <View style={Styles.row}>
+            <LoomieTypes types={loomie.types} />
+          </View>
+          <LoomieLevelBar
+            level={loomie.level}
+            experience={loomie.experience}
+            color={typeColor}
+          />
+          <LoomieStatsTable
+            level={loomie.level}
+            hp={loomie.hp}
+            defense={loomie.defense}
+            attack={loomie.attack}
+          />
+        </View>
       </View>
-    </View>
+    </>
   );
 };
 
 const Styles = StyleSheet.create({
   background: {
-    flex: 1
+    flex: 1,
+    position: 'relative'
+  },
+  fuseFloatingButton: {
+    position: 'absolute',
+    zIndex: 2,
+    top: 16,
+    right: 16,
+    width: 48,
+    height: 48,
+    borderRadius: 50,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: '#ED4A5F'
   },
   scenario: {
     height: '40%',

--- a/src/pages/UpdateLoomieTeamView.tsx
+++ b/src/pages/UpdateLoomieTeamView.tsx
@@ -3,7 +3,7 @@ import {
   getLoomiesRequest,
   putLoomieTeam
 } from '@src/services/user.services';
-import { TCaughtLoomies, TCaughtLoomiesWithTeam } from '@src/types/types';
+import { TCaughtLoomies, TCaughtLoomieToRender } from '@src/types/types';
 import React, { useEffect, useState } from 'react';
 import { LoomiesGrid } from '@src/components/CaughtLoomiesGrid/LoomiesGrid';
 import { Container } from '@src/components/Container';
@@ -20,7 +20,7 @@ interface IProps {
 
 export const UpdateLoomieTeamView = ({ navigation }: IProps) => {
   const { showErrorToast, showSuccessToast } = useToastAlert();
-  const [loomies, setLoomies] = useState(Array<TCaughtLoomiesWithTeam>);
+  const [loomies, setLoomies] = useState(Array<TCaughtLoomieToRender>);
   const [team, setTeam] = useState(Array<string>);
   const [loading, setLoading] = useState(true);
   const focused = useIsFocused();
@@ -39,10 +39,11 @@ export const UpdateLoomieTeamView = ({ navigation }: IProps) => {
     if (error) return;
 
     const loomies: TCaughtLoomies[] = response.loomies;
-    const loomiesWithTeamProperty = loomies.map((loomie) => ({
-      ...loomie,
-      is_in_team: team.includes(loomie._id)
-    }));
+
+    const loomiesWithTeamProperty = loomies.map((loomie) => {
+      const isTeamLoomie = team.includes(loomie._id);
+      return { ...loomie, is_in_team: isTeamLoomie, is_selected: isTeamLoomie };
+    });
 
     setLoomies(loomiesWithTeamProperty);
     setLoading(false);
@@ -119,7 +120,7 @@ export const UpdateLoomieTeamView = ({ navigation }: IProps) => {
         <LoomiesGrid
           loomies={loomies}
           markBusyLoomies={true}
-          markTeamLoomies={true}
+          markSelectedLoomies={true}
           elementsCallback={handleLoomiePress}
           listHeaderComponent={redirectionHeader}
         />

--- a/src/pages/UserLoomies.tsx
+++ b/src/pages/UserLoomies.tsx
@@ -3,7 +3,7 @@ import {
   getLoomieTeamService,
   getLoomiesRequest
 } from '@src/services/user.services';
-import { TCaughtLoomies, TCaughtLoomiesWithTeam } from '@src/types/types';
+import { TCaughtLoomies, TCaughtLoomieToRender } from '@src/types/types';
 import { LoomiesGrid } from '@src/components/CaughtLoomiesGrid/LoomiesGrid';
 import { Container } from '@src/components/Container';
 import { LoomiesGridSkeleton } from '@src/skeletons/CaughtLoomiesGrid/LoomiesGridSkeleton';
@@ -19,7 +19,7 @@ interface IProps {
 
 export const UserLoomies = ({ navigation }: IProps) => {
   const isFocused = useIsFocused();
-  const [loomies, setLoomies] = useState(Array<TCaughtLoomiesWithTeam>);
+  const [loomies, setLoomies] = useState(Array<TCaughtLoomieToRender>);
   const [team, setTeam] = useState(Array<string>);
   const [loading, setLoading] = useState(true);
 
@@ -43,7 +43,7 @@ export const UserLoomies = ({ navigation }: IProps) => {
   const fetchLoomieTeam = async () => {
     const [response, err] = await getLoomieTeamService();
     if (err) return;
-    const team: Array<TCaughtLoomiesWithTeam> = response.team;
+    const team: Array<TCaughtLoomieToRender> = response.team;
     setTeam(team.map((loomie) => loomie._id));
   };
 

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -18,7 +18,7 @@ export type TCaughtLoomies = {
   experience: number;
 };
 
-export type TCaughtLoomiesWithTeam = {
+export type TCaughtLoomieToRender = {
   _id: string;
   serial: number;
   name: string;
@@ -31,7 +31,10 @@ export type TCaughtLoomiesWithTeam = {
   owner: string;
   level: number;
   experience: number;
+  // Property to render the sword icon in the loomie card
   is_in_team?: boolean;
+  // Property to render a red border around the loomie card
+  is_selected?: boolean;
 };
 
 export type TWildLoomies = {


### PR DESCRIPTION
The CaughtLoomiesCard component was not working as expected inside Modals, so, the `<TouchableWithoutFeedback />`  element was replaced with the `<Pressable />` one, also, I included the following "feature"

1. Initial Fuse Loomies modal (Just to be sure the fix works as expected). @andres123dbh You can continue your work from here. 
2. `is_selected` field on Loomies. @andres123dbh you can use this field to highlight the selected Loomie in the "Fuse Loomies modal". 