### PR TITLE
Feat: Combat: Websocket, UI, and Use items

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,11 @@
-# Change this with your computer IP address and the API port on local environments
-# E.g http://192.168.x.x:8080
-API_URL = URL
+# Enable TSL
+TSL = false | true
+
+# URL x.x.x.x
+API_URL = 192.168.x.x
+
+# Port
+PORT = 8080
 
 # Show extra controls for the map
 MAP_DEBUG = false | true

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "react-native-svg": "^13.8.0",
     "react-native-toast-message": "^2.1.5",
     "react-native-vector-icons": "^9.2.0",
+    "react-use-websocket": "3",
     "yup": "^1.0.0"
   },
   "devDependencies": {

--- a/src/components/CaptureLoomie3D/utilsAnimations.ts
+++ b/src/components/CaptureLoomie3D/utilsAnimations.ts
@@ -154,7 +154,6 @@ export const attemptToCatch = async (stt: iAniState) => {
     case CAPTURE_RESULT.CAPTURED:
       {
         // print loomie info
-        console.log('CAPTURE_RESULT.CAPTURED');
         console.log(loomie);
 
         // remove captured loomie
@@ -174,8 +173,6 @@ export const attemptToCatch = async (stt: iAniState) => {
       {
         showInfoToast('Loomie escaped');
 
-        console.log('CAPTURE_RESULT.ESCAPED');
-
         // reset state
         stt.setBallState(LOOMBALL_STATE.ANI_ESCAPED);
       }
@@ -184,8 +181,6 @@ export const attemptToCatch = async (stt: iAniState) => {
       {
         // loomie disappeared
         showInfoToast('Loomie escaped');
-
-        console.log('CAPTURE_RESULT.NOTFOUND');
 
         // or user lost connection
         navigate('Map', null);

--- a/src/components/Combat/CombatFloatingMessage.tsx
+++ b/src/components/Combat/CombatFloatingMessage.tsx
@@ -32,7 +32,6 @@ export const CombatFloatingMessage = forwardRef<
 
   useImperativeHandle(ref, () => ({
     updateMessage: (message: string, direction: boolean) => {
-      console.log(message);
       setMessage(message);
       setDirection(direction);
 

--- a/src/components/Combat/CombatFloatingMessage.tsx
+++ b/src/components/Combat/CombatFloatingMessage.tsx
@@ -5,6 +5,7 @@ import React, {
   useState
 } from 'react';
 import { View, Text, Animated } from 'react-native';
+import { styles } from './combatStyles';
 
 export interface iPropsCombatFloatingMessage {
   message?: string;
@@ -97,7 +98,7 @@ export const CombatFloatingMessage = forwardRef<
             style={{ opacity: opacity.current }}
             pointerEvents='none'
           >
-            <Text>{message}</Text>
+            <Text style={styles.floatingMessage}>{message}</Text>
           </Animated.View>
         </Animated.View>
       </Animated.View>

--- a/src/components/Combat/CombatFloatingMessage.tsx
+++ b/src/components/Combat/CombatFloatingMessage.tsx
@@ -1,0 +1,69 @@
+import React, {
+  forwardRef,
+  useImperativeHandle,
+  useRef,
+  useState
+} from 'react';
+import { View, Text, Animated } from 'react-native';
+
+export interface iPropsCombatFloatingMessage {
+  message: string;
+}
+
+export interface iRefCombatFloatingMessage {
+  updateMessage: (_message: string) => void;
+}
+
+const MAX_OFFSET_BOTTOM = 100;
+const ANIMATION_DURATION = 1000;
+
+export const CombatFloatingMessage = forwardRef<
+  iRefCombatFloatingMessage,
+  iPropsCombatFloatingMessage
+>((props, ref) => {
+  const [message, setMessage] = useState<string>('');
+
+  // animation
+  const offsetBottom = useRef(new Animated.Value(0));
+  const opacity = useRef(new Animated.Value(0));
+
+  useImperativeHandle(ref, () => ({
+    updateMessage: (message: string) => {
+      console.log(message);
+      setMessage(message);
+
+      // set
+      offsetBottom.current.setValue(0);
+      opacity.current.setValue(1);
+
+      // start
+      Animated.parallel([
+        Animated.timing(offsetBottom.current, {
+          toValue: MAX_OFFSET_BOTTOM,
+          duration: ANIMATION_DURATION,
+          useNativeDriver: false
+        }),
+        Animated.timing(opacity.current, {
+          toValue: 0,
+          duration: ANIMATION_DURATION,
+          useNativeDriver: true
+        })
+      ]).start();
+    }
+  }));
+
+  //useEffect(() => {
+  //console.log(message);
+  //}, [message]);
+
+  return (
+    <View style={{ position: 'absolute', bottom: 0 }}>
+      <Animated.View style={{ opacity: opacity.current }}>
+        <Text style={{ color: 'black' }}>{props.message}</Text>
+        <Text>{message}</Text>
+      </Animated.View>
+      <Animated.View style={{ height: offsetBottom.current }}></Animated.View>
+    </View>
+  );
+});
+CombatFloatingMessage.displayName = 'CombatFloatingMessage';

--- a/src/components/Combat/CombatFloatingMessage.tsx
+++ b/src/components/Combat/CombatFloatingMessage.tsx
@@ -53,7 +53,7 @@ export const CombatFloatingMessage = forwardRef<
           Animated.timing(opacity.current, {
             toValue: 0,
             duration: ANIMATION_DURATION,
-            useNativeDriver: true
+            useNativeDriver: false
           })
         ]).start();
       }
@@ -72,7 +72,7 @@ export const CombatFloatingMessage = forwardRef<
           Animated.timing(opacity.current, {
             toValue: 0,
             duration: ANIMATION_DURATION,
-            useNativeDriver: true
+            useNativeDriver: false
           })
         ]).start();
       }

--- a/src/components/Combat/CombatLoomieInfo.tsx
+++ b/src/components/Combat/CombatLoomieInfo.tsx
@@ -9,7 +9,10 @@ interface iPropsCombatLoomieInfo {
 
 export const CombatLoomieInfo = ({ loomie }: iPropsCombatLoomieInfo) => {
   const healthPercentage = loomie
-    ? `${Math.min(100, Math.max(0, (loomie.hp / loomie.boosted_hp) * 100))}%`
+    ? `${Math.min(
+        100,
+        Math.max(0, (loomie.boosted_hp / loomie.max_hp) * 100)
+      )}%`
     : '100%';
 
   return (
@@ -25,7 +28,7 @@ export const CombatLoomieInfo = ({ loomie }: iPropsCombatLoomieInfo) => {
       </View>
       <View style={{ width: '100%', marginBottom: 5 }}>
         <Text style={styles.healthText}>
-          {loomie.hp} / {loomie.boosted_hp}
+          {loomie.boosted_hp} / {loomie.max_hp}
         </Text>
       </View>
     </View>

--- a/src/components/Combat/CombatLoomieInfo.tsx
+++ b/src/components/Combat/CombatLoomieInfo.tsx
@@ -11,7 +11,6 @@ export const CombatLoomieInfo = ({ loomie }: iPropsCombatLoomieInfo) => {
   const healthPercentage = loomie
     ? `${Math.min(100, Math.max(0, (loomie.hp / loomie.boosted_hp) * 100))}%`
     : '100%';
-  console.log(healthPercentage);
 
   return (
     <View style={styles.loomieInfoContainer}>

--- a/src/components/Combat/CombatLoomieInfo.tsx
+++ b/src/components/Combat/CombatLoomieInfo.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { View, Text } from 'react-native';
+import { styles } from './combatStyles';
+import { iLoomie } from '@src/types/combatInterfaces';
+
+interface iPropsCombatLoomieInfo {
+  loomie: iLoomie;
+}
+
+export const CombatLoomieInfo = ({ loomie }: iPropsCombatLoomieInfo) => {
+  const healthPercentage = loomie ? `${Math.min(100, Math.max(0, loomie.hp / loomie.boosted_hp * 100))}%` : '100%';
+  console.log(healthPercentage);
+
+  return (
+    <View style={styles.loomieInfoContainer}>
+      <View style={{ width: '100%', marginBottom: 3 }}>
+        <Text style={styles.infoText}>{loomie.name}</Text>
+        <Text style={{ ...styles.infoText, position: 'absolute', right: 0 }}>
+          Lvl {loomie.level}
+        </Text>
+      </View>
+      <View style={styles.healthBackground}>
+        <View style={{ ...styles.health, width: healthPercentage }}></View>
+      </View>
+      <View style={{ width: '100%', marginBottom: 5 }}>
+        <Text style={styles.healthText}>
+          {loomie.hp} / {loomie.boosted_hp}
+        </Text>
+      </View>
+    </View>
+  );
+};

--- a/src/components/Combat/CombatLoomieInfo.tsx
+++ b/src/components/Combat/CombatLoomieInfo.tsx
@@ -8,7 +8,9 @@ interface iPropsCombatLoomieInfo {
 }
 
 export const CombatLoomieInfo = ({ loomie }: iPropsCombatLoomieInfo) => {
-  const healthPercentage = loomie ? `${Math.min(100, Math.max(0, loomie.hp / loomie.boosted_hp * 100))}%` : '100%';
+  const healthPercentage = loomie
+    ? `${Math.min(100, Math.max(0, (loomie.hp / loomie.boosted_hp) * 100))}%`
+    : '100%';
   console.log(healthPercentage);
 
   return (

--- a/src/components/Combat/CombatUI.tsx
+++ b/src/components/Combat/CombatUI.tsx
@@ -20,6 +20,7 @@ import {
   iRefCombatFloatingMessage
 } from './CombatFloatingMessage';
 import { GenericModal } from '../Modals/GenericModal';
+import { SelectItemModal } from '../Modals/Combat/SelectItemModal';
 
 interface iPropsCombatUI {
   // state
@@ -41,6 +42,11 @@ interface iPropsCombatUI {
   // win modal
   modalWinVisible: boolean;
   modalWinCallback: () => void;
+
+  // use item modal
+  modalItemVisible: boolean;
+  modalItemToggle: () => void;
+  modalItemCallback: (_itemId: string) => void;
 
   // display message
   queueUpdated: number;
@@ -319,7 +325,7 @@ export const CombatUI = (props: iPropsCombatUI) => {
                   <Pressable
                     style={{ ...styles.bubbleBig }}
                     onPress={() => {
-                      console.log('Pressed loomball bubble');
+                      props.modalItemToggle();
                     }}
                   >
                     <FeatherIcon size={30} name={'box'} color={'white'} />
@@ -343,6 +349,14 @@ export const CombatUI = (props: iPropsCombatUI) => {
         labelOk='Yes'
         callbackOk={props.inputEscape}
         callbackCancel={modalEscapeToggle}
+      />
+
+      {/* use item modal */}
+
+      <SelectItemModal
+        isVisible={props.modalItemVisible}
+        toggleVisibilityCallback={props.modalItemToggle}
+        submitCallback={props.modalItemCallback}
       />
 
       {/* you loose modal */}

--- a/src/components/Combat/CombatUI.tsx
+++ b/src/components/Combat/CombatUI.tsx
@@ -20,6 +20,7 @@ import {
   iRefCombatFloatingMessage
 } from './CombatFloatingMessage';
 import { GymsModalContext } from '@src/context/GymsModalContext';
+import { CombatEscapeModal } from '../Modals/Combat/CombatEscapeModal';
 
 interface iPropsCombatUI {
   gym: TGymInfo;
@@ -57,13 +58,19 @@ export const CombatUI = ({
   removeMessageFromQueue
 }: iPropsCombatUI) => {
   // gizmo
+
   const [gizmoOrigin, setGizmoOrigin] = useState<iGridPosition>({ x: 0, y: 0 });
   const [gizmoIcon, setGizmoIcon] = useState<string>('sword-cross');
   const gizmoOpacity = useRef(new Animated.Value(0));
 
   // display messages
+
   const dispMsgs = useRef<(iRefCombatFloatingMessage | null)[]>([]);
   const distMsgIndex = useRef<number>(0);
+
+  // escape modal
+
+  const [modalEscapeVisible, setModalEscapeVisible] = useState<boolean>(false);
 
   const showGizmo = (origin: iGridPosition, icon: string) => {
     // reset
@@ -136,6 +143,12 @@ export const CombatUI = ({
     );
   };
 
+  // escape modal
+
+  const modalEscapeToggle = () => {
+    setModalEscapeVisible((value) => !value);
+  };
+
   // display message
 
   useEffect(() => {
@@ -162,161 +175,170 @@ export const CombatUI = ({
   }, [queueUpdated]);
 
   return (
-    <View style={styles.container}>
-      {/* header */}
+    <>
+      <View style={styles.container}>
+        {/* header */}
 
-      <View style={styles.circle}></View>
-      <Text style={styles.title}>{gym.name}</Text>
-      <Text style={styles.subtitle}>{gym.owner ? gym.owner : 'Unclaimed'}</Text>
+        <View style={styles.circle}></View>
+        <Text style={styles.title}>{gym.name}</Text>
+        <Text style={styles.subtitle}>
+          {gym.owner ? gym.owner : 'Unclaimed'}
+        </Text>
 
-      {/* inputs */}
+        {/* inputs */}
 
-      <View style={styles.middle}>
-        <Pressable
-          style={{ ...styles.inputDodge, height: '100%' }}
-          onPress={(evt) => touchDodge(evt, false)}
-        ></Pressable>
-        <Pressable style={{ flexGrow: 1 }} onPress={touchAttack}></Pressable>
-        <Pressable
-          style={{ ...styles.inputDodge, height: '100%' }}
-          onPress={(evt) => touchDodge(evt, true)}
-        ></Pressable>
-      </View>
+        <View style={styles.middle}>
+          <Pressable
+            style={{ ...styles.inputDodge, height: '100%' }}
+            onPress={(evt) => touchDodge(evt, false)}
+          ></Pressable>
+          <Pressable style={{ flexGrow: 1 }} onPress={touchAttack}></Pressable>
+          <Pressable
+            style={{ ...styles.inputDodge, height: '100%' }}
+            onPress={(evt) => touchDodge(evt, true)}
+          ></Pressable>
+        </View>
 
-      {/* game messages */}
+        {/* game messages */}
 
-      <View style={styles.gameMessagesContainer} pointerEvents='none'>
-        {MAX_DISPLAY_MESSAGES.map((i) => (
-          <CombatFloatingMessage
-            key={i}
-            ref={(ref) => {
-              dispMsgs.current.push(ref);
-            }}
-          />
-        ))}
-      </View>
+        <View style={styles.gameMessagesContainer} pointerEvents='none'>
+          {MAX_DISPLAY_MESSAGES.map((i) => (
+            <CombatFloatingMessage
+              key={i}
+              ref={(ref) => {
+                dispMsgs.current.push(ref);
+              }}
+            />
+          ))}
+        </View>
 
-      {/* input gizmo */}
+        {/* input gizmo */}
 
-      <View
-        style={{
-          position: 'absolute',
-          left: gizmoOrigin.x,
-          top: gizmoOrigin.y
-        }}
-      >
-        <Animated.View
-          style={{ opacity: gizmoOpacity.current }}
-          pointerEvents='none'
+        <View
+          style={{
+            position: 'absolute',
+            left: gizmoOrigin.x,
+            top: gizmoOrigin.y
+          }}
         >
-          <MaterialCommunityIcons
-            size={GIZMO_SIZE}
-            name={gizmoIcon}
-            color={'white'}
-          />
-        </Animated.View>
-      </View>
-
-      <View style={styles.top}>
-        {/* enemy loomie info */}
-
-        <View style={{ ...styles.stack, height: 72 }}>
-          <View style={{ ...styles.alignLeft, width: '70%' }}>
-            {loomieGym && <CombatLoomieInfo loomie={loomieGym} />}
-          </View>
-        </View>
-
-        {/* Enemy Loomies left */}
-
-        <View style={styles.loomiesLeftContainer}>
-          <View style={styles.loomiesLeftContainer2}>
-            {showLoomiesLeft(gymLoomiesLeft)}
-          </View>
-        </View>
-      </View>
-
-      <View style={styles.bottom}>
-        {/* user loomie info */}
-
-        <View style={{ ...styles.stack, height: 72 }}>
-          <View style={{ ...styles.alignRight, width: '70%' }}>
-            {loomiePlayer && <CombatLoomieInfo loomie={loomiePlayer} />}
-          </View>
-        </View>
-
-        {/* user Loomies left */}
-
-        <View style={{ width: '100%', height: 20 }}>
-          <View
-            style={{
-              ...styles.loomiesLeftContainer,
-              position: 'absolute',
-              right: 0
-            }}
+          <Animated.View
+            style={{ opacity: gizmoOpacity.current }}
+            pointerEvents='none'
           >
-            <View style={{ ...styles.loomiesLeftContainer2 }}>
-              {showLoomiesLeft(userLoomiesLeft)}
+            <MaterialCommunityIcons
+              size={GIZMO_SIZE}
+              name={gizmoIcon}
+              color={'white'}
+            />
+          </Animated.View>
+        </View>
+
+        <View style={styles.top}>
+          {/* enemy loomie info */}
+
+          <View style={{ ...styles.stack, height: 72 }}>
+            <View style={{ ...styles.alignLeft, width: '70%' }}>
+              {loomieGym && <CombatLoomieInfo loomie={loomieGym} />}
+            </View>
+          </View>
+
+          {/* Enemy Loomies left */}
+
+          <View style={styles.loomiesLeftContainer}>
+            <View style={styles.loomiesLeftContainer2}>
+              {showLoomiesLeft(gymLoomiesLeft)}
             </View>
           </View>
         </View>
 
-        <View style={{ ...styles.stack, height: 90 }}>
-          {/* escape bubble */}
+        <View style={styles.bottom}>
+          {/* user loomie info */}
 
-          <View style={{ ...styles.centerVertically, width: 70 }}>
-            <Pressable
-              style={styles.bubbleEscape}
-              onPress={() => {
-                console.log('ESCAPE');
-                inputEscape();
+          <View style={{ ...styles.stack, height: 72 }}>
+            <View style={{ ...styles.alignRight, width: '70%' }}>
+              {loomiePlayer && <CombatLoomieInfo loomie={loomiePlayer} />}
+            </View>
+          </View>
+
+          {/* user Loomies left */}
+
+          <View style={{ width: '100%', height: 20 }}>
+            <View
+              style={{
+                ...styles.loomiesLeftContainer,
+                position: 'absolute',
+                right: 0
               }}
             >
-              <MaterialCommunityIcons
-                size={30}
-                name={'run'}
-                color={'white'}
-                style={{ transform: [{ scaleX: -1 }] }}
-              />
-            </Pressable>
-          </View>
-
-          <View style={styles.alignRight}>
-            {/* team bubble */}
-
-            <View style={{ width: 80 }}>
-              <View style={{ ...styles.centerVertically }}>
-                <Pressable
-                  style={{ ...styles.bubbleBig }}
-                  onPress={() => {
-                    console.log('Pressed loomball bubble');
-                  }}
-                >
-                  <FeatherIcon size={30} name={'github'} color={'white'} />
-                  <View style={{ height: 4 }}></View>
-                  <Text style={styles.bubbleText}>Team</Text>
-                </Pressable>
+              <View style={{ ...styles.loomiesLeftContainer2 }}>
+                {showLoomiesLeft(userLoomiesLeft)}
               </View>
             </View>
+          </View>
 
-            {/* item bubble */}
+          <View style={{ ...styles.stack, height: 90 }}>
+            {/* escape bubble */}
 
-            <View style={{ width: 80 }}>
-              <View style={{ ...styles.centerVertically }}>
-                <Pressable
-                  style={{ ...styles.bubbleBig }}
-                  onPress={() => {
-                    console.log('Pressed loomball bubble');
-                  }}
-                >
-                  <FeatherIcon size={30} name={'box'} color={'white'} />
-                  <View style={{ height: 4 }}></View>
-                  <Text style={styles.bubbleText}>Items</Text>
-                </Pressable>
+            <View style={{ ...styles.centerVertically, width: 70 }}>
+              <Pressable
+                style={styles.bubbleEscape}
+                onPress={() => {
+                  console.log('ESCAPE');
+                  modalEscapeToggle();
+                }}
+              >
+                <MaterialCommunityIcons
+                  size={30}
+                  name={'run'}
+                  color={'white'}
+                  style={{ transform: [{ scaleX: -1 }] }}
+                />
+              </Pressable>
+            </View>
+
+            <View style={styles.alignRight}>
+              {/* team bubble */}
+
+              <View style={{ width: 80 }}>
+                <View style={{ ...styles.centerVertically }}>
+                  <Pressable
+                    style={{ ...styles.bubbleBig }}
+                    onPress={() => {
+                      console.log('Pressed loomball bubble');
+                    }}
+                  >
+                    <FeatherIcon size={30} name={'github'} color={'white'} />
+                    <View style={{ height: 4 }}></View>
+                    <Text style={styles.bubbleText}>Team</Text>
+                  </Pressable>
+                </View>
+              </View>
+
+              {/* item bubble */}
+
+              <View style={{ width: 80 }}>
+                <View style={{ ...styles.centerVertically }}>
+                  <Pressable
+                    style={{ ...styles.bubbleBig }}
+                    onPress={() => {
+                      console.log('Pressed loomball bubble');
+                    }}
+                  >
+                    <FeatherIcon size={30} name={'box'} color={'white'} />
+                    <View style={{ height: 4 }}></View>
+                    <Text style={styles.bubbleText}>Items</Text>
+                  </Pressable>
+                </View>
               </View>
             </View>
           </View>
         </View>
       </View>
-    </View>
+      <CombatEscapeModal
+        isVisible={modalEscapeVisible}
+        toggleVisibility={modalEscapeToggle}
+        escapeCombat={inputEscape}
+      />
+    </>
   );
 };

--- a/src/components/Combat/CombatUI.tsx
+++ b/src/components/Combat/CombatUI.tsx
@@ -345,7 +345,7 @@ export const CombatUI = (props: iPropsCombatUI) => {
         isVisible={modalEscapeVisible}
         toggleVisibility={modalEscapeToggle}
         title='Exit combat'
-        description='Are you sure you want to leave?'
+        description="Are you sure you want to leave? You'll have to wait to fight this gym again"
         labelOk='Yes'
         callbackOk={props.inputEscape}
         callbackCancel={modalEscapeToggle}

--- a/src/components/Combat/CombatUI.tsx
+++ b/src/components/Combat/CombatUI.tsx
@@ -1,0 +1,141 @@
+import React from 'react';
+import { View, Text, Pressable, Image } from 'react-native';
+import MaterialCommunityIcons from 'react-native-vector-icons/MaterialCommunityIcons';
+import FeatherIcon from 'react-native-vector-icons/Feather';
+import { styles } from './combatStyles';
+import { Gap } from '../Gap';
+import { iLoomie } from '@src/types/combatInterfaces';
+import { TGymInfo } from '@src/types/types';
+import { CombatLoomieInfo } from './CombatLoomieInfo';
+
+interface iPropsCombatUI {
+  gym: TGymInfo;
+  loomiePlayer: iLoomie;
+  loomieGym: iLoomie;
+}
+
+export const CombatUI = ({gym, loomiePlayer, loomieGym}: iPropsCombatUI) => {
+  return (
+    <View style={styles.container}>
+
+      {/* header */}
+
+      <View style={styles.circle}></View>
+      <Text style={styles.title}>{gym.name}</Text>
+      <Text style={styles.subtitle}>{gym.owner ? gym.owner : 'Unclaimed'}</Text>
+
+      <View
+        style={{
+          ...styles.stack,
+          top: styles?.circle?.top + styles?.circle?.height + 7,
+          position: 'absolute'
+        }}
+      >
+        {/* enemy loomie info */}
+
+        <View style={{ ...styles.stack, height: 72 }}>
+          <View style={{ ...styles.alignLeft, width: '70%' }}>
+            { loomieGym && <CombatLoomieInfo loomie={loomieGym}/> }
+          </View>
+        </View>
+
+        {/* Enemy Loomies left */}
+
+        <View style={styles.enemyLoomiesContainer}>
+          <View style={styles.enemyLoomiesContainer2}>
+            <View
+              style={{ ...styles.loomieON, ...styles.loomieDiamond }}
+            ></View>
+            <Gap size={10} direction={'horizontal'}/>
+            <View
+              style={{ ...styles.loomieON, ...styles.loomieDiamond }}
+            ></View>
+            <Gap size={10} direction={'horizontal'}/>
+            <View
+              style={{ ...styles.loomieON, ...styles.loomieDiamond }}
+            ></View>
+            <Gap size={10} direction={'horizontal'}/>
+            <View
+              style={{ ...styles.loomieActive, ...styles.loomieDiamond }}
+            ></View>
+            <Gap size={10} direction={'horizontal'}/>
+            <View
+              style={{ ...styles.loomieOFF, ...styles.loomieDiamond }}
+            ></View>
+            <Gap size={10} direction={'horizontal'}/>
+            <View
+              style={{ ...styles.loomieOFF, ...styles.loomieDiamond }}
+            ></View>
+          </View>
+        </View>
+      </View>
+
+      <View style={styles.bottom}>
+
+        {/* user loomie info */}
+
+        <View style={{ ...styles.stack, height: 72 }}>
+          <View style={{ ...styles.alignRight, width: '70%' }}>
+            { loomiePlayer && <CombatLoomieInfo loomie={loomiePlayer}/> }
+          </View>
+        </View>
+
+        <View style={{ ...styles.stack, height: 90 }}>
+          {/* scape bubble */}
+
+          <View style={{ ...styles.centerVertically, width: 70 }}>
+            <Pressable
+              style={styles.bubbleEscape}
+              onPress={() => {
+                console.log('ESCAPE');
+              }}
+            >
+              <MaterialCommunityIcons
+                size={30}
+                name={'run'}
+                color={'white'}
+                style={{ transform: [{ scaleX: -1 }] }}
+              />
+            </Pressable>
+          </View>
+
+          <View style={styles.alignRight}>
+            {/* team bubble */}
+
+            <View style={{ width: 80 }}>
+              <View style={{ ...styles.centerVertically }}>
+                <Pressable
+                  style={{ ...styles.bubbleBig }}
+                  onPress={() => {
+                    console.log('Pressed loomball bubble');
+                  }}
+                >
+                  <FeatherIcon size={30} name={'github'} color={'white'} />
+                  <View style={{ height: 4 }}></View>
+                  <Text style={styles.bubbleText}>Team</Text>
+                </Pressable>
+              </View>
+            </View>
+
+            {/* item bubble */}
+
+            <View style={{ width: 80 }}>
+              <View style={{ ...styles.centerVertically }}>
+                <Pressable
+                  style={{ ...styles.bubbleBig }}
+                  onPress={() => {
+                    console.log('Pressed loomball bubble');
+                  }}
+                >
+                  <FeatherIcon size={30} name={'box'} color={'white'} />
+                  <View style={{ height: 4 }}></View>
+                  <Text style={styles.bubbleText}>Items</Text>
+                </Pressable>
+              </View>
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+  );
+};

--- a/src/components/Combat/CombatUI.tsx
+++ b/src/components/Combat/CombatUI.tsx
@@ -38,6 +38,10 @@ interface iPropsCombatUI {
   modalLooseVisible: boolean;
   modalLooseCallback: () => void;
 
+  // win modal
+  modalWinVisible: boolean;
+  modalWinCallback: () => void;
+
   // display message
   queueUpdated: number;
   getMessageQueue: () => iDisplayMessage[];
@@ -345,10 +349,20 @@ export const CombatUI = (props: iPropsCombatUI) => {
 
       <GenericModal
         isVisible={props.modalLooseVisible}
-        title='You have no Loomies left'
-        description='Good luck next time'
+        title='Defeat'
+        description='You have no Loomies left in your team. Good luck next time.'
         labelOk='Return to map'
         callbackOk={props.modalLooseCallback}
+      />
+
+      {/* you win modal */}
+
+      <GenericModal
+        isVisible={props.modalWinVisible}
+        title='Victory'
+        description="You own this gym now. You can get better rewards from this gym as long as it's yours."
+        labelOk='Return to map'
+        callbackOk={props.modalWinCallback}
       />
     </>
   );

--- a/src/components/Combat/CombatUI.tsx
+++ b/src/components/Combat/CombatUI.tsx
@@ -19,11 +19,15 @@ import {
   CombatFloatingMessage,
   iRefCombatFloatingMessage
 } from './CombatFloatingMessage';
+import { GymsModalContext } from '@src/context/GymsModalContext';
 
 interface iPropsCombatUI {
   gym: TGymInfo;
   loomiePlayer: iLoomie;
   loomieGym: iLoomie;
+  gymLoomiesLeft: number;
+  userLoomiesLeft: number;
+
   inputAttack: () => void;
   inputDodge: (_direction: boolean) => void;
   inputEscape: () => void;
@@ -35,11 +39,15 @@ interface iPropsCombatUI {
 
 const GIZMO_SIZE = 30;
 const MAX_DISPLAY_MESSAGES = [0, 1, 2, 3];
+const MAX_LOOMIES = [0, 1, 2, 3, 4, 5];
 
 export const CombatUI = ({
   gym,
   loomiePlayer,
   loomieGym,
+  gymLoomiesLeft,
+  userLoomiesLeft,
+
   inputAttack,
   inputDodge,
   inputEscape,
@@ -93,6 +101,39 @@ export const CombatUI = ({
       'shield-half-full'
     );
     inputDodge(direction);
+  };
+
+  // loomies left
+
+  const showLoomiesLeft = (quantity: number) => {
+    quantity--;
+
+    return (
+      <>
+        {MAX_LOOMIES.map((i) => (
+          <React.Fragment key={i}>
+            {i < quantity && (
+              <View
+                style={{ ...styles.loomieDiamond, ...styles.loomieON }}
+              ></View>
+            )}
+            {i == quantity && (
+              <View
+                style={{ ...styles.loomieDiamond, ...styles.loomieActive }}
+              ></View>
+            )}
+            {i > quantity && (
+              <View
+                style={{ ...styles.loomieDiamond, ...styles.loomieOFF }}
+              ></View>
+            )}
+            {i != MAX_LOOMIES.length - 1 && (
+              <Gap size={10} direction={'horizontal'} />
+            )}
+          </React.Fragment>
+        ))}
+      </>
+    );
   };
 
   // display message
@@ -187,31 +228,9 @@ export const CombatUI = ({
 
         {/* Enemy Loomies left */}
 
-        <View style={styles.enemyLoomiesContainer}>
-          <View style={styles.enemyLoomiesContainer2}>
-            <View
-              style={{ ...styles.loomieON, ...styles.loomieDiamond }}
-            ></View>
-            <Gap size={10} direction={'horizontal'} />
-            <View
-              style={{ ...styles.loomieON, ...styles.loomieDiamond }}
-            ></View>
-            <Gap size={10} direction={'horizontal'} />
-            <View
-              style={{ ...styles.loomieON, ...styles.loomieDiamond }}
-            ></View>
-            <Gap size={10} direction={'horizontal'} />
-            <View
-              style={{ ...styles.loomieActive, ...styles.loomieDiamond }}
-            ></View>
-            <Gap size={10} direction={'horizontal'} />
-            <View
-              style={{ ...styles.loomieOFF, ...styles.loomieDiamond }}
-            ></View>
-            <Gap size={10} direction={'horizontal'} />
-            <View
-              style={{ ...styles.loomieOFF, ...styles.loomieDiamond }}
-            ></View>
+        <View style={styles.loomiesLeftContainer}>
+          <View style={styles.loomiesLeftContainer2}>
+            {showLoomiesLeft(gymLoomiesLeft)}
           </View>
         </View>
       </View>
@@ -222,6 +241,22 @@ export const CombatUI = ({
         <View style={{ ...styles.stack, height: 72 }}>
           <View style={{ ...styles.alignRight, width: '70%' }}>
             {loomiePlayer && <CombatLoomieInfo loomie={loomiePlayer} />}
+          </View>
+        </View>
+
+        {/* user Loomies left */}
+
+        <View style={{ width: '100%', height: 20 }}>
+          <View
+            style={{
+              ...styles.loomiesLeftContainer,
+              position: 'absolute',
+              right: 0
+            }}
+          >
+            <View style={{ ...styles.loomiesLeftContainer2 }}>
+              {showLoomiesLeft(userLoomiesLeft)}
+            </View>
           </View>
         </View>
 

--- a/src/components/Combat/CombatUI.tsx
+++ b/src/components/Combat/CombatUI.tsx
@@ -12,9 +12,11 @@ interface iPropsCombatUI {
   gym: TGymInfo;
   loomiePlayer: iLoomie;
   loomieGym: iLoomie;
+  inputAttack: () => void;
+  inputDodge: (_direction: boolean) => void;
 }
 
-export const CombatUI = ({gym, loomiePlayer, loomieGym}: iPropsCombatUI) => {
+export const CombatUI = ({gym, loomiePlayer, loomieGym, inputAttack, inputDodge}: iPropsCombatUI) => {
   return (
     <View style={styles.container}>
 
@@ -24,12 +26,19 @@ export const CombatUI = ({gym, loomiePlayer, loomieGym}: iPropsCombatUI) => {
       <Text style={styles.title}>{gym.name}</Text>
       <Text style={styles.subtitle}>{gym.owner ? gym.owner : 'Unclaimed'}</Text>
 
+      { /* inputs */ }
+
+      <View style={styles.middle}>
+        <Pressable style={{...styles.inputDodge, height: '100%'}} onPress={() => inputDodge(false)}>
+        </Pressable>
+        <Pressable style={{flexGrow: 1, backgroundColor: 'red'}} onPress={inputAttack}>
+        </Pressable>
+        <Pressable style={{...styles.inputDodge, height: '100%'}} onPress={() => inputDodge(true)}>
+        </Pressable>
+      </View>
+
       <View
-        style={{
-          ...styles.stack,
-          top: styles?.circle?.top + styles?.circle?.height + 7,
-          position: 'absolute'
-        }}
+        style={styles.top}
       >
         {/* enemy loomie info */}
 
@@ -69,6 +78,7 @@ export const CombatUI = ({gym, loomiePlayer, loomieGym}: iPropsCombatUI) => {
           </View>
         </View>
       </View>
+
 
       <View style={styles.bottom}>
 

--- a/src/components/Combat/CombatUI.tsx
+++ b/src/components/Combat/CombatUI.tsx
@@ -20,7 +20,7 @@ import {
   iRefCombatFloatingMessage
 } from './CombatFloatingMessage';
 import { GymsModalContext } from '@src/context/GymsModalContext';
-import { CombatEscapeModal } from '../Modals/Combat/CombatEscapeModal';
+import { GenericModal } from '../Modals/GenericModal';
 
 interface iPropsCombatUI {
   gym: TGymInfo;
@@ -334,10 +334,14 @@ export const CombatUI = ({
           </View>
         </View>
       </View>
-      <CombatEscapeModal
+      <GenericModal
         isVisible={modalEscapeVisible}
         toggleVisibility={modalEscapeToggle}
-        escapeCombat={inputEscape}
+        title='Exit combat'
+        description='Are you sure you want to leave?'
+        labelOk='Yes'
+        callbackOk={inputEscape}
+        callbackCancel={modalEscapeToggle}
       />
     </>
   );

--- a/src/components/Combat/CombatUI.tsx
+++ b/src/components/Combat/CombatUI.tsx
@@ -26,6 +26,7 @@ interface iPropsCombatUI {
   loomieGym: iLoomie;
   inputAttack: () => void;
   inputDodge: (_direction: boolean) => void;
+  inputEscape: () => void;
 
   queueUpdated: number;
   getMessageQueue: () => iDisplayMessage[];
@@ -41,6 +42,7 @@ export const CombatUI = ({
   loomieGym,
   inputAttack,
   inputDodge,
+  inputEscape,
 
   queueUpdated,
   getMessageQueue,
@@ -62,7 +64,7 @@ export const CombatUI = ({
 
     setGizmoOrigin({
       x: origin.x - GIZMO_SIZE / 2,
-      y: origin.y - GIZMO_SIZE
+      y: origin.y - (GIZMO_SIZE * 3) / 4
     });
     setGizmoIcon(icon);
 
@@ -106,7 +108,7 @@ export const CombatUI = ({
 
       const el =
         dispMsgs.current[distMsgIndex.current % MAX_DISPLAY_MESSAGES.length];
-      if (el) el.updateMessage(msg.message);
+      if (el) el.updateMessage(msg.message, msg.direction);
       distMsgIndex.current += 1;
 
       // gather ids
@@ -133,14 +135,24 @@ export const CombatUI = ({
           style={{ ...styles.inputDodge, height: '100%' }}
           onPress={(evt) => touchDodge(evt, false)}
         ></Pressable>
-        <Pressable
-          style={{ flexGrow: 1, backgroundColor: 'red' }}
-          onPress={touchAttack}
-        ></Pressable>
+        <Pressable style={{ flexGrow: 1 }} onPress={touchAttack}></Pressable>
         <Pressable
           style={{ ...styles.inputDodge, height: '100%' }}
           onPress={(evt) => touchDodge(evt, true)}
         ></Pressable>
+      </View>
+
+      {/* game messages */}
+
+      <View style={styles.gameMessagesContainer} pointerEvents='none'>
+        {MAX_DISPLAY_MESSAGES.map((i) => (
+          <CombatFloatingMessage
+            key={i}
+            ref={(ref) => {
+              dispMsgs.current.push(ref);
+            }}
+          />
+        ))}
       </View>
 
       {/* input gizmo */}
@@ -205,20 +217,6 @@ export const CombatUI = ({
       </View>
 
       <View style={styles.bottom}>
-        {/* game messages */}
-
-        <View style={styles.gameMessagesContainer}>
-          {MAX_DISPLAY_MESSAGES.map((i) => (
-            <CombatFloatingMessage
-              message='soso'
-              key={i}
-              ref={(ref) => {
-                dispMsgs.current.push(ref);
-              }}
-            />
-          ))}
-        </View>
-
         {/* user loomie info */}
 
         <View style={{ ...styles.stack, height: 72 }}>
@@ -228,13 +226,14 @@ export const CombatUI = ({
         </View>
 
         <View style={{ ...styles.stack, height: 90 }}>
-          {/* scape bubble */}
+          {/* escape bubble */}
 
           <View style={{ ...styles.centerVertically, width: 70 }}>
             <Pressable
               style={styles.bubbleEscape}
               onPress={() => {
                 console.log('ESCAPE');
+                inputEscape();
               }}
             >
               <MaterialCommunityIcons

--- a/src/components/Combat/CombatUI.tsx
+++ b/src/components/Combat/CombatUI.tsx
@@ -91,7 +91,7 @@ export const CombatUI = (props: iPropsCombatUI) => {
       Animated.timing(gizmoOpacity.current, {
         toValue: 0,
         duration: 500,
-        useNativeDriver: true
+        useNativeDriver: false
       })
     ]).start();
   };

--- a/src/components/Combat/CombatUI.tsx
+++ b/src/components/Combat/CombatUI.tsx
@@ -287,7 +287,6 @@ export const CombatUI = (props: iPropsCombatUI) => {
               <Pressable
                 style={styles.bubbleEscape}
                 onPress={() => {
-                  console.log('ESCAPE');
                   modalEscapeToggle();
                 }}
               >
@@ -308,7 +307,7 @@ export const CombatUI = (props: iPropsCombatUI) => {
                   <Pressable
                     style={{ ...styles.bubbleBig }}
                     onPress={() => {
-                      console.log('Pressed loomball bubble');
+                      console.log('Pressed Loomie team bubble');
                     }}
                   >
                     <FeatherIcon size={30} name={'github'} color={'white'} />

--- a/src/components/Combat/combatStyles.ts
+++ b/src/components/Combat/combatStyles.ts
@@ -235,7 +235,7 @@ export const styles = StyleSheet.create({
 
   middle: {
     position: 'absolute',
-    top: HEADER_HEIGHT + 110,
+    top: HEADER_HEIGHT + 140,
     bottom: HEADER_HEIGHT + 100,
     flexGrow: 1,
     width: '100%',

--- a/src/components/Combat/combatStyles.ts
+++ b/src/components/Combat/combatStyles.ts
@@ -233,23 +233,27 @@ export const styles = StyleSheet.create({
   // middle (inputs)
 
   middle: {
+    //backgroundColor: 'green',
     position: 'absolute',
     top: HEADER_HEIGHT + 140,
     bottom: HEADER_HEIGHT + 100,
     flexGrow: 1,
     width: '100%',
-    backgroundColor: 'green',
     flexDirection: 'row'
   },
 
   inputDodge: {
-    width: '20%',
-    backgroundColor: 'blue'
+    //backgroundColor: 'blue'
+    width: '20%'
   },
 
   gameMessagesContainer: {
+    //backgroundColor: 'purple',
+    position: 'absolute',
+    top: HEADER_HEIGHT + 115,
+    bottom: HEADER_HEIGHT + 100,
+    flexGrow: 1,
     width: '100%',
-
-    alignItems: 'center'
+    flexDirection: 'row'
   }
 });

--- a/src/components/Combat/combatStyles.ts
+++ b/src/components/Combat/combatStyles.ts
@@ -6,7 +6,7 @@ const colors = {
   healthGray: '#EDEDED',
   border: '#C2E9FF',
 
-  enemyLoomiesContainer: '#E8E8E8',
+  loomiesLeftContainer: '#E8E8E8',
   loomieActive: '#31B5FF',
   loomieOFF: '#8D8D8D'
 };
@@ -189,19 +189,19 @@ export const styles = StyleSheet.create({
 
   // remaining enemy loomies
 
-  enemyLoomiesContainer: {
+  loomiesLeftContainer: {
     marginHorizontal: 5,
     borderWidth: 3,
     borderColor: colors.border,
     borderRadius: 8,
 
-    backgroundColor: colors.enemyLoomiesContainer,
-    width: '50%',
-    height: 32,
-    marginTop: 5
+    backgroundColor: colors.border,
+    width: '40%',
+    height: 0,
+    marginTop: 10
   },
 
-  enemyLoomiesContainer2: {
+  loomiesLeftContainer2: {
     flexDirection: 'row',
     flex: 1,
 
@@ -213,8 +213,8 @@ export const styles = StyleSheet.create({
     borderWidth: 3,
     borderColor: colors.border,
 
-    width: 18,
-    height: 18,
+    width: 15,
+    height: 15,
     transform: [{ rotate: '45deg' }]
   },
 

--- a/src/components/Combat/combatStyles.ts
+++ b/src/components/Combat/combatStyles.ts
@@ -1,0 +1,218 @@
+import { StyleSheet } from 'react-native';
+
+const colors = {
+  white: 'white',
+  red: '#ED4A5F',
+  healthGray: '#EDEDED',
+  border: '#C2E9FF',
+
+  enemyLoomiesContainer: '#E8E8E8',
+  loomieActive: '#31B5FF',
+  loomieOFF: '#8D8D8D'
+};
+
+export const styles = StyleSheet.create({
+  container: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    width: '100%',
+    height: '100%',
+
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: 'teal'
+  },
+
+  scene: {
+    width: '100%',
+    height: '100%'
+  },
+
+  circle: {
+    height: 220,
+    width: 230,
+    borderRadius: 200,
+    backgroundColor: colors.red,
+    position: 'absolute',
+    top: -160,
+    transform: [{ scaleX: 2 }]
+  },
+
+  title: {
+    position: 'absolute',
+    top: 10,
+    fontSize: 18,
+    fontWeight: 'bold',
+    color: 'white'
+  },
+
+  subtitle: {
+    position: 'absolute',
+    top: 32,
+    fontSize: 14,
+    color: 'white'
+  },
+
+  bubbleBig: {
+    borderWidth: 1,
+    borderColor: 'transparent',
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: 70,
+    height: 70,
+    backgroundColor: colors.red,
+    borderRadius: 200
+  },
+
+  bubbleText: {
+    color: 'white',
+    fontSize: 14,
+    fontWeight: 'bold'
+  },
+
+  // botom
+
+  bottom: {
+    // backgroundColor: 'blue',
+    position: 'absolute',
+    bottom: 0,
+
+    width: '100%'
+    //height: 100,
+  },
+
+  stack: {
+    width: '100%',
+    height: 50
+  },
+
+  centerVertically: {
+    //backgroundColor: 'red',
+    height: '100%',
+    width: '100%',
+
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center'
+  },
+
+  alignRight: {
+    //backgroundColor: 'pink',
+    position: 'absolute',
+    right: 0,
+    flexDirection: 'row',
+
+    height: '100%',
+    width: 'auto'
+  },
+
+  alignLeft: {
+    //backgroundColor: 'pink',
+    position: 'absolute',
+    left: 0,
+    flexDirection: 'row',
+
+    height: '100%',
+    width: 1
+  },
+
+  bubbleEscape: {
+    borderWidth: 1,
+    borderColor: 'transparent',
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: 55,
+    height: 55,
+
+    backgroundColor: '#00000022',
+    borderRadius: 200
+  },
+
+  // loomie info
+
+  loomieInfoContainer: {
+    borderWidth: 3,
+    borderColor: colors.border,
+    borderRadius: 15,
+    paddingHorizontal: 10,
+    marginHorizontal: 5,
+
+    backgroundColor: 'white',
+    width: '100%',
+    height: '100%',
+
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center'
+  },
+
+  infoText: {
+    color: 'black',
+    fontSize: 15
+  },
+
+  healthText: {
+    color: 'gray',
+    //color: colors.red,
+    fontSize: 12
+  },
+
+  healthBackground: {
+    borderWidth: 2,
+    borderColor: colors.border,
+
+    width: '100%',
+    backgroundColor: colors.healthGray,
+    height: 15
+  },
+
+  health: {
+    backgroundColor: colors.red,
+    height: '100%'
+  },
+
+  // remaining enemy loomies
+
+  enemyLoomiesContainer: {
+    marginHorizontal: 5,
+    borderWidth: 3,
+    borderColor: colors.border,
+    borderRadius: 8,
+
+    backgroundColor: colors.enemyLoomiesContainer,
+    width: '50%',
+    height: 32,
+    marginTop: 5
+  },
+
+  enemyLoomiesContainer2: {
+    flexDirection: 'row',
+    flex: 1,
+
+    justifyContent: 'center',
+    alignItems: 'center'
+  },
+
+  loomieDiamond: {
+    borderWidth: 3,
+    borderColor: colors.border,
+
+    width: 18,
+    height: 18,
+    transform: [{ rotate: '45deg' }]
+  },
+
+  loomieON: {
+    backgroundColor: colors.red
+  },
+
+  loomieActive: {
+    backgroundColor: colors.loomieActive
+  },
+
+  loomieOFF: {
+    backgroundColor: colors.loomieOFF
+  }
+});

--- a/src/components/Combat/combatStyles.ts
+++ b/src/components/Combat/combatStyles.ts
@@ -12,8 +12,8 @@ const colors = {
 };
 
 const HEADER_HEIGHT = -160 + 220 + 7;
-const TOP_HEIGHT = 0
-const BOTTOM_HEIGHT = 0
+const TOP_HEIGHT = 0;
+const BOTTOM_HEIGHT = 0;
 
 export const styles = StyleSheet.create({
   container: {
@@ -85,7 +85,6 @@ export const styles = StyleSheet.create({
     top: HEADER_HEIGHT,
     position: 'absolute'
   },
-  
 
   // bottom
 
@@ -245,7 +244,12 @@ export const styles = StyleSheet.create({
 
   inputDodge: {
     width: '20%',
-    backgroundColor: 'blue',
-  }
+    backgroundColor: 'blue'
+  },
 
+  gameMessagesContainer: {
+    width: '100%',
+
+    alignItems: 'center'
+  }
 });

--- a/src/components/Combat/combatStyles.ts
+++ b/src/components/Combat/combatStyles.ts
@@ -11,6 +11,10 @@ const colors = {
   loomieOFF: '#8D8D8D'
 };
 
+const HEADER_HEIGHT = -160 + 220 + 7;
+const TOP_HEIGHT = 0
+const BOTTOM_HEIGHT = 0
+
 export const styles = StyleSheet.create({
   container: {
     position: 'absolute',
@@ -29,6 +33,8 @@ export const styles = StyleSheet.create({
     width: '100%',
     height: '100%'
   },
+
+  // header
 
   circle: {
     height: 220,
@@ -72,7 +78,16 @@ export const styles = StyleSheet.create({
     fontWeight: 'bold'
   },
 
-  // botom
+  // top
+
+  top: {
+    width: '100%',
+    top: HEADER_HEIGHT,
+    position: 'absolute'
+  },
+  
+
+  // bottom
 
   bottom: {
     // backgroundColor: 'blue',
@@ -214,5 +229,23 @@ export const styles = StyleSheet.create({
 
   loomieOFF: {
     backgroundColor: colors.loomieOFF
+  },
+
+  // middle (inputs)
+
+  middle: {
+    position: 'absolute',
+    top: HEADER_HEIGHT + 110,
+    bottom: HEADER_HEIGHT + 100,
+    flexGrow: 1,
+    width: '100%',
+    backgroundColor: 'green',
+    flexDirection: 'row'
+  },
+
+  inputDodge: {
+    width: '20%',
+    backgroundColor: 'blue',
   }
+
 });

--- a/src/components/Combat/combatStyles.ts
+++ b/src/components/Combat/combatStyles.ts
@@ -12,8 +12,6 @@ const colors = {
 };
 
 const HEADER_HEIGHT = -160 + 220 + 7;
-const TOP_HEIGHT = 0;
-const BOTTOM_HEIGHT = 0;
 
 export const styles = StyleSheet.create({
   container: {
@@ -248,10 +246,10 @@ export const styles = StyleSheet.create({
   },
 
   gameMessagesContainer: {
-    //backgroundColor: 'purple',
+    //backgroundColor: 'purple', // uncomment to make adjusts
     position: 'absolute',
-    top: HEADER_HEIGHT + 115,
-    bottom: HEADER_HEIGHT + 100,
+    top: HEADER_HEIGHT + 100,
+    bottom: HEADER_HEIGHT + 120,
     flexGrow: 1,
     width: '100%',
     flexDirection: 'row'

--- a/src/components/Combat/combatStyles.ts
+++ b/src/components/Combat/combatStyles.ts
@@ -255,5 +255,11 @@ export const styles = StyleSheet.create({
     flexGrow: 1,
     width: '100%',
     flexDirection: 'row'
+  },
+
+  floatingMessage: {
+    color: 'white',
+    fontWeight: '500',
+    fontSize: 16
   }
 });

--- a/src/components/Combat/combatUtils.ts
+++ b/src/components/Combat/combatUtils.ts
@@ -10,11 +10,11 @@ export const getCombatToken = async (
   const [data, error] = await requestCombatRegister(userPos, gymId);
 
   // code 400
-  if (error == 400) {
+  if (error.length) {
     const { showInfoToast } = useToastAlert();
 
     // show toast
-    showInfoToast('No Loomies in your team');
+    showInfoToast(error);
 
     return null;
   }

--- a/src/components/Combat/combatUtils.ts
+++ b/src/components/Combat/combatUtils.ts
@@ -1,0 +1,16 @@
+import { requestCombatRegister } from "@src/services/combat.services";
+import { iPosition } from "@src/types/mapInterfaces";
+import { iRequestCombatRegister } from "@src/types/requestInterfaces";
+
+
+export const getCombatToken = async (userPos: iPosition, gymId: string): Promise<string | null> => {
+
+  // try to register combat
+  const data: iRequestCombatRegister | null = await requestCombatRegister(userPos, gymId);
+
+  // TODO: Show toast when you have to wait for it
+  // Maybe it's better to return the error message in that case
+  if (!data) return null;
+
+  return data.combat_token;
+};

--- a/src/components/Combat/combatUtils.ts
+++ b/src/components/Combat/combatUtils.ts
@@ -1,16 +1,23 @@
 import { requestCombatRegister } from '@src/services/combat.services';
 import { iPosition } from '@src/types/mapInterfaces';
-import { iRequestCombatRegister } from '@src/types/requestInterfaces';
+import { useToastAlert } from '@src/hooks/useToastAlert';
 
 export const getCombatToken = async (
   userPos: iPosition,
   gymId: string
 ): Promise<string | null> => {
   // try to register combat
-  const data: iRequestCombatRegister | null = await requestCombatRegister(
-    userPos,
-    gymId
-  );
+  const [data, error] = await requestCombatRegister(userPos, gymId);
+
+  // code 400
+  if (error == 400) {
+    const { showInfoToast } = useToastAlert();
+
+    // show toast
+    showInfoToast('No Loomies in your team');
+
+    return null;
+  }
 
   // TODO: Show toast when you have to wait for it
   // Maybe it's better to return the error message in that case

--- a/src/components/Combat/combatUtils.ts
+++ b/src/components/Combat/combatUtils.ts
@@ -1,12 +1,16 @@
-import { requestCombatRegister } from "@src/services/combat.services";
-import { iPosition } from "@src/types/mapInterfaces";
-import { iRequestCombatRegister } from "@src/types/requestInterfaces";
+import { requestCombatRegister } from '@src/services/combat.services';
+import { iPosition } from '@src/types/mapInterfaces';
+import { iRequestCombatRegister } from '@src/types/requestInterfaces';
 
-
-export const getCombatToken = async (userPos: iPosition, gymId: string): Promise<string | null> => {
-
+export const getCombatToken = async (
+  userPos: iPosition,
+  gymId: string
+): Promise<string | null> => {
   // try to register combat
-  const data: iRequestCombatRegister | null = await requestCombatRegister(userPos, gymId);
+  const data: iRequestCombatRegister | null = await requestCombatRegister(
+    userPos,
+    gymId
+  );
 
   // TODO: Show toast when you have to wait for it
   // Maybe it's better to return the error message in that case

--- a/src/components/Gap.tsx
+++ b/src/components/Gap.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { View } from 'react-native';
+
+export function Gap({
+  size,
+  direction = 'horizontal'
+}: {
+  size: number;
+  direction: string;
+}) {
+  return (
+    <View style={{ [direction === 'horizontal' ? 'width' : 'height']: size }} />
+  );
+}

--- a/src/components/ItemsGrid/ItemCard.tsx
+++ b/src/components/ItemsGrid/ItemCard.tsx
@@ -2,7 +2,7 @@ import { TInventoryItem } from '@src/types/types';
 import { images } from '@src/utils/utils';
 import React from 'react';
 import { Image, StyleSheet, Text, View } from 'react-native';
-import { TouchableWithoutFeedback } from 'react-native-gesture-handler';
+import { Pressable } from 'react-native';
 
 interface IProps {
   item: TInventoryItem;
@@ -14,7 +14,7 @@ export const ItemCard = ({ item, handleClickCallback }: IProps) => {
 
   return (
     <View style={Styles.card}>
-      <TouchableWithoutFeedback
+      <Pressable
         onPress={() => {
           // Call the callback if it exists and pass the item
           handleClickCallback && handleClickCallback(item);
@@ -41,7 +41,7 @@ export const ItemCard = ({ item, handleClickCallback }: IProps) => {
             </View>
           </View>
         </View>
-      </TouchableWithoutFeedback>
+      </Pressable>
     </View>
   );
 };

--- a/src/components/ItemsGrid/SelectItemGrid.tsx
+++ b/src/components/ItemsGrid/SelectItemGrid.tsx
@@ -1,0 +1,54 @@
+import { TInventoryItem, TItem } from '@src/types/types';
+import React, { useState } from 'react';
+import { FlatList } from 'react-native-gesture-handler';
+import { ItemCard } from './ItemCard';
+import { SelectItemDetailsModal } from '../Modals/Combat/SelectItemDetailsModal';
+
+interface iPropsSelectItemGrid {
+  items: Array<TItem>;
+  submitItem: (_itemId: string) => void;
+}
+
+export const SelectItemGrid = (props: iPropsSelectItemGrid) => {
+  const [itemModalVisible, setItemModalVisible] = useState(true);
+  const [selectedItem, setSelectedItem] = useState<TItem | null>(null);
+
+  const toggleItemModalVisibility = (visible?: boolean) => {
+    if (visible != undefined) setItemModalVisible(visible);
+    else setItemModalVisible(!itemModalVisible);
+  };
+
+  const handleItemPress = (item: TInventoryItem) => {
+    // Find the item by the id and show the information
+    const clickedItem = props.items.find((i) => i._id === item._id);
+
+    if (clickedItem) {
+      setSelectedItem(clickedItem);
+      toggleItemModalVisibility(true);
+    }
+  };
+
+  return (
+    <>
+      {selectedItem && (
+        <SelectItemDetailsModal
+          isVisible={itemModalVisible}
+          toggleVisibility={() => toggleItemModalVisibility()}
+          submitItem={props.submitItem}
+          item={selectedItem}
+        />
+      )}
+      <FlatList
+        data={props.items}
+        keyExtractor={(item) => item._id}
+        renderItem={({ item }) => (
+          <ItemCard
+            item={{ ...item, type: 'item' } as TInventoryItem}
+            handleClickCallback={handleItemPress}
+          />
+        )}
+        numColumns={2}
+      />
+    </>
+  );
+};

--- a/src/components/Map3D/Map3DEngine.tsx
+++ b/src/components/Map3D/Map3DEngine.tsx
@@ -198,17 +198,17 @@ export const Map3DEngine = () => {
           sceneMap
         );
 
-        console.log('A2');
+        console.log('A1');
         if (playerModel && playerNode.current) {
           playerModel.setParent(playerNode.current);
         }
-        console.log('A3');
+        console.log('A1');
 
         if (circleIndicatorModel && playerNode.current) {
           circleIndicatorModel.position.y = CIRCLE_INDICATOR_HEIGHT;
           circleIndicatorModel.setParent(playerNode.current);
         }
-        console.log('A4');
+        console.log('A1');
       } catch (error) {
         console.log("ERROR: Couldn't load model.");
       }

--- a/src/components/Modals/Combat/CombatEscapeModal.tsx
+++ b/src/components/Modals/Combat/CombatEscapeModal.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import Modal from 'react-native-modal';
+import { CustomButton } from '@src/components/CustomButton';
+
+interface IProps {
+  isVisible: boolean;
+  toggleVisibility: () => void;
+  escapeCombat: () => void;
+}
+
+export const CombatEscapeModal = ({
+  isVisible,
+  toggleVisibility,
+  escapeCombat
+}: IProps) => {
+  return (
+    <Modal isVisible={isVisible} onBackdropPress={toggleVisibility}>
+      <View style={Styles.container}>
+        <View style={Styles.background}>
+          <Text style={{ ...Styles.modalText, ...Styles.textTitle }}>
+            Exit combat
+          </Text>
+          <Text style={{ ...Styles.modalText, ...Styles.textDescription }}>
+            Are you sure you want lo leave?
+          </Text>
+          <CustomButton title='Yes' type='bordered' callback={escapeCombat} />
+          <CustomButton
+            title='Cancel'
+            type='bordered'
+            callback={toggleVisibility}
+          />
+        </View>
+      </View>
+    </Modal>
+  );
+};
+
+const Styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center'
+  },
+  background: {
+    width: '80%',
+    padding: 16,
+    backgroundColor: 'white'
+  },
+  modalText: {
+    color: '#5C5C5C'
+  },
+  textTitle: {
+    textAlign: 'center',
+    fontSize: 18,
+    fontWeight: 'bold',
+    marginVertical: 8
+  },
+  textDescription: {
+    textAlign: 'center',
+    fontSize: 16,
+    marginVertical: 8
+  }
+});

--- a/src/components/Modals/Combat/SelectItemDetailsModal.tsx
+++ b/src/components/Modals/Combat/SelectItemDetailsModal.tsx
@@ -1,0 +1,100 @@
+import { TItem } from '@src/types/types';
+import { images } from '@src/utils/utils';
+import React from 'react';
+import { Image, StyleSheet, Text, View } from 'react-native';
+import Modal from 'react-native-modal';
+import { CustomButton } from '@src/components/CustomButton';
+
+interface iPropsSelectItemDetailsModal {
+  isVisible: boolean;
+  toggleVisibility: () => void;
+
+  item: TItem;
+  submitItem: (_itemId: string) => void;
+}
+
+export const SelectItemDetailsModal = (props: iPropsSelectItemDetailsModal) => {
+  const itemSerial = props.item.serial.toString().padStart(3, '0');
+
+  return (
+    <Modal isVisible={props.isVisible} onBackdropPress={props.toggleVisibility}>
+      <View style={Styles.container}>
+        <View style={Styles.background}>
+          <View style={Styles.cardImageBg} />
+          <Image source={images[`O-${itemSerial}`]} style={Styles.itemImage} />
+          <Text style={{ ...Styles.modalText, ...Styles.itemQuantity }}>
+            x{props.item.quantity}
+          </Text>
+          <Text style={{ ...Styles.modalText, ...Styles.itemName }}>
+            {props.item.name}
+          </Text>
+          <Text style={{ ...Styles.modalText, ...Styles.itemDescription }}>
+            {props.item.description}
+          </Text>
+          <CustomButton
+            title='Use now'
+            type='primary'
+            // send item id
+            callback={() => {
+              props.submitItem(props.item._id);
+            }}
+          />
+          <CustomButton
+            title='Close'
+            type='bordered'
+            callback={props.toggleVisibility}
+          />
+        </View>
+      </View>
+    </Modal>
+  );
+};
+
+const Styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center'
+  },
+  background: {
+    width: '80%',
+    padding: 16,
+    backgroundColor: 'white'
+  },
+  modalText: {
+    color: '#5C5C5C'
+  },
+  cardImageBg: {
+    alignSelf: 'center',
+    backgroundColor: 'rgba(0,0,0,0.065)',
+    borderRadius: 24,
+    height: 110,
+    position: 'absolute',
+    top: 36,
+    transform: [{ rotate: '35deg' }],
+    width: 110
+  },
+  itemImage: {
+    width: 150,
+    height: 150,
+    resizeMode: 'contain',
+    alignSelf: 'center'
+  },
+  itemQuantity: {
+    position: 'absolute',
+    top: 16,
+    right: 16,
+    fontSize: 18
+  },
+  itemName: {
+    textAlign: 'center',
+    fontSize: 18,
+    fontWeight: 'bold',
+    marginVertical: 8
+  },
+  itemDescription: {
+    textAlign: 'center',
+    fontSize: 16,
+    marginVertical: 8
+  }
+});

--- a/src/components/Modals/Combat/SelectItemModal.tsx
+++ b/src/components/Modals/Combat/SelectItemModal.tsx
@@ -1,4 +1,4 @@
-import { getItemsService } from '@src/services/user.services';
+import { getItemsService } from '@src/services/items.services';
 import { TItem } from '@src/types/types';
 import React, { useCallback, useEffect, useState } from 'react';
 import { StyleSheet, Text, View } from 'react-native';

--- a/src/components/Modals/Combat/SelectItemModal.tsx
+++ b/src/components/Modals/Combat/SelectItemModal.tsx
@@ -1,0 +1,91 @@
+import { getItemsService } from '@src/services/user.services';
+import { TItem } from '@src/types/types';
+import React, { useCallback, useEffect, useState } from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import Modal from 'react-native-modal';
+
+import { SelectItemGrid } from '@src/components/ItemsGrid/SelectItemGrid';
+import { CustomButton } from '@src/components/CustomButton';
+import { EmptyMessage } from '@src/components/EmptyMessage';
+
+export interface iPropsSelectItemModal {
+  isVisible: boolean;
+  toggleVisibilityCallback: () => void;
+  submitCallback: (_itemId: string) => void;
+}
+
+export const SelectItemModal = (props: iPropsSelectItemModal) => {
+  const [items, setItems] = useState<TItem[]>([]);
+
+  // get items
+
+  const fetchItems = async () => {
+    const data = await getItemsService();
+    if (!data) return;
+
+    // only items usable in combat
+
+    const items = data.items.filter((item) => item.is_combat_item);
+    console.log(items.length);
+
+    setItems(data.items);
+  };
+
+  // fetch on visible
+
+  useEffect(() => {
+    if (!props.isVisible) return;
+    fetchItems();
+  }, [props.isVisible]);
+
+  const handleLoomiePress = useCallback((id: string) => {
+    console.log('Info: Item pressed: ', id);
+
+    props.submitCallback(id);
+    props.toggleVisibilityCallback();
+  }, []);
+
+  return (
+    <Modal
+      isVisible={props.isVisible}
+      onBackButtonPress={props.toggleVisibilityCallback}
+      onBackdropPress={props.toggleVisibilityCallback}
+      style={Styles.modal}
+    >
+      <Text style={Styles.modalTitle}>Items</Text>
+      <View style={{ flex: 1, marginVertical: 8 }}>
+        {items.length === 0 ? (
+          <EmptyMessage text={"You don't have any items"} showButton={false} />
+        ) : (
+          <SelectItemGrid items={items} submitItem={handleLoomiePress} />
+        )}
+      </View>
+      <View style={Styles.containerButton}>
+        <CustomButton
+          title='Cancel'
+          type='primary'
+          callback={props.toggleVisibilityCallback}
+        />
+      </View>
+    </Modal>
+  );
+};
+
+const Styles = StyleSheet.create({
+  modal: {
+    backgroundColor: '#fff',
+    width: '90%',
+    padding: 12
+  },
+  modalTitle: {
+    color: '#ED4A5F',
+    fontSize: 26,
+    fontWeight: 'bold',
+    textAlign: 'center',
+    textTransform: 'uppercase'
+  },
+  containerButton: {
+    alignSelf: 'center',
+    width: '90%'
+  }
+});

--- a/src/components/Modals/Combat/SelectItemModal.tsx
+++ b/src/components/Modals/Combat/SelectItemModal.tsx
@@ -24,10 +24,6 @@ export const SelectItemModal = (props: iPropsSelectItemModal) => {
     if (!data) return;
 
     // only items usable in combat
-
-    const items = data.items.filter((item) => item.is_combat_item);
-    console.log(items.length);
-
     setItems(data.items);
   };
 

--- a/src/components/Modals/GenericModal.tsx
+++ b/src/components/Modals/GenericModal.tsx
@@ -5,7 +5,7 @@ import { CustomButton } from '@src/components/CustomButton';
 
 interface IProps {
   isVisible: boolean;
-  toggleVisibility: () => void;
+  toggleVisibility?: () => void;
 
   title: string;
   description: string;
@@ -31,7 +31,10 @@ export const GenericModal = ({
   callbackCancel
 }: IProps) => {
   return (
-    <Modal isVisible={isVisible} onBackdropPress={toggleVisibility}>
+    <Modal
+      isVisible={isVisible}
+      onBackdropPress={toggleVisibility ? toggleVisibility : undefined}
+    >
       <View style={Styles.container}>
         <View style={Styles.background}>
           <Text style={{ ...Styles.modalText, ...Styles.textTitle }}>

--- a/src/components/Modals/GenericModal.tsx
+++ b/src/components/Modals/GenericModal.tsx
@@ -6,30 +6,52 @@ import { CustomButton } from '@src/components/CustomButton';
 interface IProps {
   isVisible: boolean;
   toggleVisibility: () => void;
-  escapeCombat: () => void;
+
+  title: string;
+  description: string;
+
+  labelOk?: string;
+  labelCancel?: string;
+
+  callbackOk: () => void;
+  callbackCancel?: () => void;
 }
 
-export const CombatEscapeModal = ({
+export const GenericModal = ({
   isVisible,
   toggleVisibility,
-  escapeCombat
+
+  title,
+  description,
+
+  labelOk,
+  labelCancel,
+
+  callbackOk,
+  callbackCancel
 }: IProps) => {
   return (
     <Modal isVisible={isVisible} onBackdropPress={toggleVisibility}>
       <View style={Styles.container}>
         <View style={Styles.background}>
           <Text style={{ ...Styles.modalText, ...Styles.textTitle }}>
-            Exit combat
+            {title}
           </Text>
           <Text style={{ ...Styles.modalText, ...Styles.textDescription }}>
-            Are you sure you want lo leave?
+            {description}
           </Text>
-          <CustomButton title='Yes' type='primary' callback={escapeCombat} />
           <CustomButton
-            title='Cancel'
-            type='bordered'
-            callback={toggleVisibility}
+            title={labelOk ? labelOk : 'Ok'}
+            type='primary'
+            callback={callbackOk}
           />
+          {callbackCancel && (
+            <CustomButton
+              title={labelCancel ? labelCancel : 'Cancel'}
+              type='bordered'
+              callback={callbackCancel}
+            />
+          )}
         </View>
       </View>
     </Modal>

--- a/src/components/Modals/Gyms/ModalGym.tsx
+++ b/src/components/Modals/Gyms/ModalGym.tsx
@@ -67,7 +67,10 @@ export const ModalGym = () => {
     // get token
 
     const combatToken = await getCombatToken(userPosition, gymInfo._id);
-    if (!combatToken) return;
+    if (!combatToken) {
+      toggleGymModalVisibility();
+      return;
+    }
 
     const params: iCombatViewParams = {
       gym: gymInfo,

--- a/src/components/Modals/Gyms/ModalGym.tsx
+++ b/src/components/Modals/Gyms/ModalGym.tsx
@@ -134,6 +134,9 @@ export const ModalGym = () => {
             <Text style={Styles.modalSubtitle}>
               Owner: {gymInfo.owner == null ? 'Unclaimed' : gymInfo.owner}
             </Text>
+            {gymInfo.user_owns_it && (
+              <Text style={Styles.modalSubtitle}>(You own this gym)</Text>
+            )}
             <View style={Styles.protectorsContainer}>
               <View style={Styles.containerButton}>
                 <Text style={Styles.flastListTitle}>Protectors:</Text>
@@ -153,14 +156,16 @@ export const ModalGym = () => {
                   callback={fetchClaimRewards}
                 />
               )}
-              <CustomButton
-                title='Challenge'
-                type='primary'
-                callback={() => {
-                  console.log('Challenge');
-                  goToCombat();
-                }}
-              />
+              {!gymInfo.user_owns_it && (
+                <CustomButton
+                  title='Challenge'
+                  type='primary'
+                  callback={() => {
+                    console.log('Challenge');
+                    goToCombat();
+                  }}
+                />
+              )}
             </View>
           </View>
         </View>

--- a/src/components/Modals/Gyms/ModalGym.tsx
+++ b/src/components/Modals/Gyms/ModalGym.tsx
@@ -74,6 +74,9 @@ export const ModalGym = () => {
       combatToken: combatToken
     };
 
+    // close modal before going to combat view
+
+    toggleGymModalVisibility();
     navigate('Combat', params);
   };
 

--- a/src/components/Modals/Gyms/ModalGym.tsx
+++ b/src/components/Modals/Gyms/ModalGym.tsx
@@ -10,10 +10,15 @@ import { TGymInfo, TGymLoomieProtector, TReward } from '../../../types/types';
 import { getPosition } from '@src/services/geolocation.services';
 import { requestRewards } from '@src/services/map.services';
 import { useToastAlert } from '@src/hooks/useToastAlert';
+import { navigate } from '@src/navigation/RootNavigation';
+import { getCombatToken } from '@src/components/Combat/combatUtils';
+import { UserPositionContext } from '@src/context/UserPositionProvider';
+import { iCombatViewParams } from '@src/pages/CombatView';
 
 export const ModalGym = () => {
   const { isGymModalOpen, currentModalGymId, toggleGymModalVisibility } =
     useContext(GymsModalContext);
+  const { userPosition } = useContext(UserPositionContext);
 
   const { showErrorToast } = useToastAlert();
   const [rewardsModalVisible, setRewardsModalVisible] = useState(false);
@@ -52,6 +57,24 @@ export const ModalGym = () => {
         setReward(reward || []);
       }
     }
+  };
+
+  // start combat
+  const goToCombat = async () => {
+    if (!gymInfo) return;
+    if (!userPosition) return;
+
+    // get token
+
+    const combatToken = await getCombatToken(userPosition, gymInfo._id);
+    if (!combatToken) return;
+
+    const params: iCombatViewParams = {
+      gym: gymInfo,
+      combatToken: combatToken
+    }
+
+    navigate('Combat', params);
   };
 
   // Open the second modal if the user has claimed the rewards successfully
@@ -132,6 +155,7 @@ export const ModalGym = () => {
                 type='primary'
                 callback={() => {
                   console.log('Challenge');
+                  goToCombat();
                 }}
               />
             </View>

--- a/src/components/Modals/Gyms/ModalGym.tsx
+++ b/src/components/Modals/Gyms/ModalGym.tsx
@@ -72,7 +72,7 @@ export const ModalGym = () => {
     const params: iCombatViewParams = {
       gym: gymInfo,
       combatToken: combatToken
-    }
+    };
 
     navigate('Combat', params);
   };

--- a/src/components/Modals/Gyms/ModalGym.tsx
+++ b/src/components/Modals/Gyms/ModalGym.tsx
@@ -164,7 +164,6 @@ export const ModalGym = () => {
                   title='Challenge'
                   type='primary'
                   callback={() => {
-                    console.log('Challenge');
                     goToCombat();
                   }}
                 />

--- a/src/context/BabylonProvider.tsx
+++ b/src/context/BabylonProvider.tsx
@@ -8,6 +8,7 @@ import * as Babylon from '@babylonjs/core';
 import { useEngineRenderLoop } from '@src/hooks/useEngineRenderLoop';
 import { useEngine } from '@babylonjs/react-native';
 import { ArcRotateCamera } from '@babylonjs/core';
+import { delay } from '@src/utils/delay';
 
 export const enum APP_SCENE {
   NONE,
@@ -238,8 +239,3 @@ export const BabylonProvider = (props: { children: ReactNode }) => {
     </BabylonContext.Provider>
   );
 };
-
-const delay = (ms: number): Promise<void> =>
-  new Promise((resolve): void => {
-    setTimeout(resolve, ms);
-  });

--- a/src/context/UserPositionProvider.tsx
+++ b/src/context/UserPositionProvider.tsx
@@ -5,6 +5,7 @@
 
 import React, { createContext, useEffect, useState, ReactNode } from 'react';
 import { iPosition, getPosition } from '@src/services/geolocation.services';
+import { delay } from '@src/utils/delay';
 import { CONFIG } from '@src/services/config.services';
 const { MAP_DEBUG } = CONFIG;
 
@@ -68,8 +69,3 @@ export const UserPositionProvider = (props: { children: ReactNode }) => {
     </UserPositionContext.Provider>
   );
 };
-
-const delay = (ms: number): Promise<void> =>
-  new Promise((resolve): void => {
-    setTimeout(resolve, ms);
-  });

--- a/src/pages/CombatView.tsx
+++ b/src/pages/CombatView.tsx
@@ -96,7 +96,6 @@ export const CombatView = ({ route }: iCombatViewProps) => {
   // connection closed
 
   useEffect(() => {
-    console.log('readyState', readyState);
     if (readyState == ReadyState.CLOSED) {
       // it's a disconnection and not a normal ending
 
@@ -127,9 +126,6 @@ export const CombatView = ({ route }: iCombatViewProps) => {
 
     if ((rawData as iCombatMessage) === undefined) return;
     const data = rawData as iCombatMessage;
-
-    console.log(data.type);
-    console.log(data.payload);
 
     const messageType = data.type as keyof typeof TYPE;
     switch (TYPE[messageType]) {
@@ -416,8 +412,6 @@ export const CombatView = ({ route }: iCombatViewProps) => {
   const getMessageQueue = (): iDisplayMessage[] => displayMessageQueue.current;
   const removeMessageFromQueue = (deletedIds: number[]) => {
     // filter deleted ids
-
-    console.log(deletedIds);
 
     displayMessageQueue.current = displayMessageQueue.current.filter((msg) => {
       return (

--- a/src/pages/CombatView.tsx
+++ b/src/pages/CombatView.tsx
@@ -491,8 +491,6 @@ export const CombatView = ({ _navigation, route }: iCombatViewProps) => {
           removeMessageFromQueue={removeMessageFromQueue}
         />
       )}
-
-      <Text>{route.params.gym.name}</Text>
     </>
   );
 };

--- a/src/pages/CombatView.tsx
+++ b/src/pages/CombatView.tsx
@@ -82,7 +82,7 @@ export const CombatView = ({ _navigation, route }: iCombatViewProps) => {
     console.log(data.type);
     console.log(data.payload);
 
-    queueMessage(data.type, false);
+    //queueMessage(data.type, false);
 
     const messageType = data.type as keyof typeof TYPE;
     switch (TYPE[messageType]) {
@@ -109,10 +109,39 @@ export const CombatView = ({ _navigation, route }: iCombatViewProps) => {
             return;
           const payload = data.payload as iPayload_UPDATE_USER_LOOMIE_HP;
 
-          console.log(payload.hp);
-
           setLoomiePlayer((loomie) => {
             if (loomie) {
+              // queue display message
+
+              const hpDiff = payload.hp - loomie.hp;
+              if (hpDiff < 0) queueMessage(hpDiff.toString(), false);
+
+              // update hp
+
+              loomie.hp = payload.hp;
+              return { ...loomie, hp: payload.hp };
+            }
+          });
+        }
+        break;
+
+      // update gym hp
+
+      case TYPE.UPDATE_GYM_LOOMIE_HP:
+        {
+          if ((data.payload as iPayload_UPDATE_USER_LOOMIE_HP) === undefined)
+            return;
+          const payload = data.payload as iPayload_UPDATE_USER_LOOMIE_HP;
+
+          setLoomieGym((loomie) => {
+            if (loomie) {
+              // queue display message
+
+              const hpDiff = payload.hp - loomie.hp;
+              if (hpDiff < 0) queueMessage(hpDiff.toString(), true);
+
+              // update hp
+
               loomie.hp = payload.hp;
               return { ...loomie, hp: payload.hp };
             }
@@ -132,23 +161,6 @@ export const CombatView = ({ _navigation, route }: iCombatViewProps) => {
         }
         break;
 
-      // update gym hp
-
-      case TYPE.UPDATE_GYM_LOOMIE_HP:
-        {
-          if ((data.payload as iPayload_UPDATE_USER_LOOMIE_HP) === undefined)
-            return;
-          const payload = data.payload as iPayload_UPDATE_USER_LOOMIE_HP;
-
-          setLoomieGym((loomie) => {
-            if (loomie) {
-              loomie.hp = payload.hp;
-              return { ...loomie, hp: payload.hp };
-            }
-          });
-        }
-        break;
-
       // update gym loomie
 
       case TYPE.UPDATE_GYM_LOOMIE:
@@ -158,6 +170,34 @@ export const CombatView = ({ _navigation, route }: iCombatViewProps) => {
           const payload = data.payload as iPayload_UPDATE_PLAYER_LOOMIE;
 
           setLoomieGym({ ...payload.loomie, hp: payload.loomie.boosted_hp });
+        }
+        break;
+
+      // loomie weakened
+
+      case TYPE.GYM_LOOMIE_WEAKENED:
+        {
+          queueMessage('Enemy Loomie has weakened', true);
+        }
+        break;
+
+      case TYPE.USER_LOOMIE_WEAKENED:
+        {
+          queueMessage('Your Loomie has weakened', false);
+        }
+        break;
+
+      // attack dodged
+
+      case TYPE.GYM_ATTACK_DODGED:
+        {
+          queueMessage('Dodged', false);
+        }
+        break;
+
+      case TYPE.USER_ATTACK_DODGED:
+        {
+          queueMessage('Dodged', true);
         }
         break;
 
@@ -173,20 +213,13 @@ export const CombatView = ({ _navigation, route }: iCombatViewProps) => {
     const message = JSON.stringify({
       type: TYPE[TYPE.USER_ATTACK] as string
     });
-
-    console.log(message);
-
-    queueMessage('-33', true);
     sendMessage(message, false);
   };
 
-  const userDodge = (direction: boolean) => {
+  const userDodge = (_direction: boolean) => {
     const message = JSON.stringify({
       type: TYPE[TYPE.USER_DODGE] as string
     });
-
-    console.log(message, direction);
-
     sendMessage(message, false);
   };
 

--- a/src/pages/CombatView.tsx
+++ b/src/pages/CombatView.tsx
@@ -17,6 +17,7 @@ import {
   iPayload_GYM_LOOMIE_WEAKENED,
   iPayload_USER_LOOMIE_WEAKENED
 } from '@src/types/combatInterfaces';
+import { useToastAlert } from '@src/hooks/useToastAlert';
 const { WS_URL } = CONFIG;
 
 interface iPayload {
@@ -43,6 +44,9 @@ interface iCombatViewProps {
 }
 
 export const CombatView = ({ _navigation, route }: iCombatViewProps) => {
+  // toast
+  const { showInfoToast } = useToastAlert();
+
   // web socket
   const url = `${WS_URL}/combat?token=${route.params.combatToken}`;
   const { sendMessage, lastMessage, readyState } = useWebSocket(url);
@@ -258,6 +262,12 @@ export const CombatView = ({ _navigation, route }: iCombatViewProps) => {
         }
         break;
 
+      // leave
+
+      case TYPE.ESCAPE_COMBAT:
+        exitCombat();
+        break;
+
       default:
         console.log(`Warn: Message not recognized ${data.type}`);
         break;
@@ -281,6 +291,18 @@ export const CombatView = ({ _navigation, route }: iCombatViewProps) => {
   };
 
   const userEscape = () => {
+    const message = JSON.stringify({
+      type: TYPE[TYPE.USER_ESCAPE_COMBAT] as string
+    });
+
+    // send multiple
+    sendMessage(message, true);
+    sendMessage(message, true);
+    sendMessage(message, true);
+  };
+
+  const exitCombat = () => {
+    showInfoToast('Combat has ended');
     navigate('Map', null);
   };
 

--- a/src/pages/CombatView.tsx
+++ b/src/pages/CombatView.tsx
@@ -40,7 +40,7 @@ interface iCombatViewProps {
   route: RouteProp<{ params: iCombatViewParams }, 'params'>;
 }
 
-export const CombatView = ({ _navigation, route }: iCombatViewProps) => {
+export const CombatView = ({ route }: iCombatViewProps) => {
   // toast
 
   const { showInfoToast, showErrorToast } = useToastAlert();

--- a/src/pages/CombatView.tsx
+++ b/src/pages/CombatView.tsx
@@ -127,7 +127,13 @@ export const CombatView = ({ _navigation, route }: iCombatViewProps) => {
               // queue display message
 
               const hpDiff = payload.hp - loomie.hp;
-              if (hpDiff < 0) queueMessage(hpDiff.toString(), false);
+              if (hpDiff < 0)
+                queueMessage(
+                  payload.was_critical
+                    ? `Effective attack! ${hpDiff}`
+                    : `${hpDiff}`,
+                  false
+                );
 
               // update hp
 
@@ -151,7 +157,13 @@ export const CombatView = ({ _navigation, route }: iCombatViewProps) => {
               // queue display message
 
               const hpDiff = payload.hp - loomie.hp;
-              if (hpDiff < 0) queueMessage(hpDiff.toString(), true);
+              if (hpDiff < 0)
+                queueMessage(
+                  payload.was_critical
+                    ? `Effective attack! ${hpDiff}`
+                    : `${hpDiff}`,
+                  true
+                );
 
               // update hp
 

--- a/src/pages/CombatView.tsx
+++ b/src/pages/CombatView.tsx
@@ -16,7 +16,8 @@ import {
   iPayload_UPDATE_PLAYER_LOOMIE,
   iPayload_GYM_LOOMIE_WEAKENED,
   iPayload_USER_LOOMIE_WEAKENED,
-  iPayload_USER_ITEM_USED
+  iPayload_USER_ITEM_USED,
+  iPayload_ERROR_USING_ITEM
 } from '@src/types/combatInterfaces';
 import { useToastAlert } from '@src/hooks/useToastAlert';
 import { delay } from '@src/utils/delay';
@@ -299,7 +300,7 @@ export const CombatView = ({ _navigation, route }: iCombatViewProps) => {
         }
         break;
 
-      // use item
+      // items
 
       case TYPE.USER_ITEM_USED:
         {
@@ -328,6 +329,22 @@ export const CombatView = ({ _navigation, route }: iCombatViewProps) => {
           }
 
           queueMessage(message, false);
+        }
+        break;
+
+      case TYPE.ERROR_USING_ITEM:
+        {
+          if ((data.payload as iPayload_ERROR_USING_ITEM) === undefined) return;
+          const payload = data.payload as iPayload_ERROR_USING_ITEM;
+
+          switch (payload.error_reason) {
+            case 'USER_ALREADY_HEALED':
+              queueMessage('Loomie already healed', false);
+              break;
+            case 'USER_NOT_WEAKENED':
+              queueMessage('Selected Loomie is not weakened', false);
+              break;
+          }
         }
         break;
 

--- a/src/pages/CombatView.tsx
+++ b/src/pages/CombatView.tsx
@@ -156,12 +156,22 @@ export const CombatView = ({ _navigation, route }: iCombatViewProps) => {
     }
   }, [lastMessage]);
 
-  const attack = () => {
+  const userAttack = () => {
     const message = JSON.stringify({
       type: TYPE[TYPE.USER_ATTACK] as string
     });
 
     console.log(message);
+
+    sendMessage(message, false);
+  };
+
+  const userDodge = (direction: boolean) => {
+    const message = JSON.stringify({
+      type: TYPE[TYPE.USER_DODGE] as string
+    });
+
+    console.log(message, direction);
 
     sendMessage(message, false);
   };
@@ -186,8 +196,8 @@ export const CombatView = ({ _navigation, route }: iCombatViewProps) => {
           gym={route.params.gym}
           loomiePlayer={loomiePlayer}
           loomieGym={loomieGym}
-          inputAttack={attack}
-          inputDodge={attack}
+          inputAttack={userAttack}
+          inputDodge={userDodge}
         />
       )}
 

--- a/src/pages/CombatView.tsx
+++ b/src/pages/CombatView.tsx
@@ -64,11 +64,25 @@ export const CombatView = ({ _navigation, route }: iCombatViewProps) => {
 
   const [modalLooseVisible, setModalLooseVisible] = useState<boolean>(false);
   const [modalWinVisible, setModalWinVisible] = useState<boolean>(false);
-  const modalLooseToggle = () => {
-    setModalLooseVisible((value) => !value);
+  const [modalItemVisible, setModalItemVisible] = useState<boolean>(false);
+  const modalLooseToggle = (open?: boolean) => {
+    if (open != undefined) setModalLooseVisible(open);
+    else setModalLooseVisible((value) => !value);
   };
-  const modalWinToggle = () => {
-    setModalWinVisible((value) => !value);
+  const modalWinToggle = (open?: boolean) => {
+    if (open != undefined) setModalWinVisible(open);
+    else setModalWinVisible((value) => !value);
+  };
+  const modalItemToggle = (open?: boolean) => {
+    if (open != undefined) {
+      setModalItemVisible(open);
+    } else setModalItemVisible((value) => !value);
+  };
+
+  const modalCloseAll = () => {
+    modalLooseToggle(false);
+    modalWinToggle(false);
+    modalItemToggle(false);
   };
 
   useEffect(() => {
@@ -272,7 +286,8 @@ export const CombatView = ({ _navigation, route }: iCombatViewProps) => {
             if (loomie) return { ...loomie, hp: 0 };
           });
 
-          modalWinToggle();
+          modalCloseAll();
+          modalWinToggle(true);
           queueMessage('You win', false);
         }
         break;
@@ -284,7 +299,8 @@ export const CombatView = ({ _navigation, route }: iCombatViewProps) => {
             if (loomie) return { ...loomie, hp: 0 };
           });
 
-          modalLooseToggle();
+          modalCloseAll();
+          modalLooseToggle(true);
           queueMessage('You have lost', false);
         }
         break;
@@ -406,6 +422,14 @@ export const CombatView = ({ _navigation, route }: iCombatViewProps) => {
           // win modal
           modalWinVisible={modalWinVisible}
           modalWinCallback={() => {
+            showInfoToast('Combat has ended');
+            exitCombat();
+          }}
+          // use item modal
+          modalItemVisible={modalItemVisible}
+          modalItemToggle={() => modalItemToggle()}
+          modalItemCallback={(item: string) => {
+            console.log(`Info: selected ${item}`);
             showInfoToast('Combat has ended');
             exitCombat();
           }}

--- a/src/pages/CombatView.tsx
+++ b/src/pages/CombatView.tsx
@@ -26,6 +26,7 @@ interface iPayload {
 export interface iDisplayMessage {
   id: number;
   message: string;
+  direction: boolean;
 }
 
 export interface iCombatViewParams {
@@ -81,7 +82,7 @@ export const CombatView = ({ _navigation, route }: iCombatViewProps) => {
     console.log(data.type);
     console.log(data.payload);
 
-    queueMessage(data.type);
+    queueMessage(data.type, false);
 
     const messageType = data.type as keyof typeof TYPE;
     switch (TYPE[messageType]) {
@@ -175,6 +176,7 @@ export const CombatView = ({ _navigation, route }: iCombatViewProps) => {
 
     console.log(message);
 
+    queueMessage('-33', true);
     sendMessage(message, false);
   };
 
@@ -188,9 +190,13 @@ export const CombatView = ({ _navigation, route }: iCombatViewProps) => {
     sendMessage(message, false);
   };
 
+  const userEscape = () => {
+    navigate('Map', null);
+  };
+
   // display message queue
 
-  const queueMessage = (message: string) => {
+  const queueMessage = (message: string, direction: boolean) => {
     let currentId = 0;
 
     // increase ids
@@ -200,7 +206,11 @@ export const CombatView = ({ _navigation, route }: iCombatViewProps) => {
     });
 
     // push
-    displayMessageQueue.current.push({ id: currentId, message: message });
+    displayMessageQueue.current.push({
+      id: currentId,
+      message: message,
+      direction: direction
+    });
   };
 
   const getMessageQueue = (): iDisplayMessage[] => displayMessageQueue.current;
@@ -217,12 +227,6 @@ export const CombatView = ({ _navigation, route }: iCombatViewProps) => {
         })
       );
     });
-
-    // trigger update
-
-    //setQueueUpdated((count) => {
-    //return count + 1;
-    //});
   };
 
   return (
@@ -247,6 +251,7 @@ export const CombatView = ({ _navigation, route }: iCombatViewProps) => {
           loomieGym={loomieGym}
           inputAttack={userAttack}
           inputDodge={userDodge}
+          inputEscape={userEscape}
           queueUpdated={queueUpdated}
           getMessageQueue={getMessageQueue}
           removeMessageFromQueue={removeMessageFromQueue}
@@ -256,5 +261,4 @@ export const CombatView = ({ _navigation, route }: iCombatViewProps) => {
       <Text>{route.params.gym.name}</Text>
     </>
   );
-  //return <Text >Hel</Text>;
 };

--- a/src/pages/CombatView.tsx
+++ b/src/pages/CombatView.tsx
@@ -63,8 +63,12 @@ export const CombatView = ({ _navigation, route }: iCombatViewProps) => {
   // modals
 
   const [modalLooseVisible, setModalLooseVisible] = useState<boolean>(false);
+  const [modalWinVisible, setModalWinVisible] = useState<boolean>(false);
   const modalLooseToggle = () => {
     setModalLooseVisible((value) => !value);
+  };
+  const modalWinToggle = () => {
+    setModalWinVisible((value) => !value);
   };
 
   useEffect(() => {
@@ -79,7 +83,7 @@ export const CombatView = ({ _navigation, route }: iCombatViewProps) => {
     if (readyState == ReadyState.CLOSED) {
       // it's a disconnection and not a normal ending
 
-      if (!modalLooseVisible) {
+      if (!(modalLooseVisible || modalWinVisible)) {
         showErrorToast('Connection lost');
         exitCombat();
       }
@@ -106,10 +110,9 @@ export const CombatView = ({ _navigation, route }: iCombatViewProps) => {
 
     if ((rawData as iCombatMessage) === undefined) return;
     const data = rawData as iCombatMessage;
+
     console.log(data.type);
     console.log(data.payload);
-
-    //queueMessage(data.type, false);
 
     const messageType = data.type as keyof typeof TYPE;
     switch (TYPE[messageType]) {
@@ -120,8 +123,7 @@ export const CombatView = ({ _navigation, route }: iCombatViewProps) => {
           if ((data.payload as iPayload_START) === undefined) return;
           const payload = data.payload as iPayload_START;
 
-          console.log('start start start');
-          console.log(payload.gym_loomie);
+          // update loomies
 
           setLoomieGym({
             ...payload.gym_loomie,
@@ -131,6 +133,8 @@ export const CombatView = ({ _navigation, route }: iCombatViewProps) => {
             ...payload.player_loomie,
             hp: payload.player_loomie.boosted_hp
           });
+
+          // update loomies left
 
           setGymLoomiesLeft(payload.alive_gym_loomies);
           setUserLoomiesLeft(payload.alive_user_loomies);
@@ -267,6 +271,8 @@ export const CombatView = ({ _navigation, route }: iCombatViewProps) => {
           setLoomieGym((loomie) => {
             if (loomie) return { ...loomie, hp: 0 };
           });
+
+          modalWinToggle();
           queueMessage('You win', false);
         }
         break;
@@ -394,6 +400,12 @@ export const CombatView = ({ _navigation, route }: iCombatViewProps) => {
           // loose modal
           modalLooseVisible={modalLooseVisible}
           modalLooseCallback={() => {
+            showInfoToast('Combat has ended');
+            exitCombat();
+          }}
+          // win modal
+          modalWinVisible={modalWinVisible}
+          modalWinCallback={() => {
             showInfoToast('Combat has ended');
             exitCombat();
           }}

--- a/src/pages/CombatView.tsx
+++ b/src/pages/CombatView.tsx
@@ -1,6 +1,133 @@
-import React from 'react';
-import { Text } from 'react-native';
+import React, { useEffect, useState } from 'react';
+import { NavigationProp, RouteProp } from '@react-navigation/core';
+import { View, Text, SafeAreaView } from 'react-native';
+import useWebSocket, { ReadyState } from 'react-use-websocket';
 
-export const CombatView = () => {
-  return <Text>Combat View</Text>;
+import { CombatUI } from '@src/components/Combat/CombatUI';
+import { navigate } from '@src/navigation/RootNavigation';
+import { TGymInfo } from '@src/types/types';
+import { CONFIG } from '@src/services/config.services';
+import { iCombatMessage, iPayload_START, iPayload_UPDATE_USER_LOOMIE_HP, iLoomie, TYPE } from '@src/types/combatInterfaces';
+const { WS_URL } = CONFIG;
+
+interface iPayload {
+  type: string;
+  message: string;
+  payload: any;
+}
+
+export interface iCombatViewParams {
+  gym: TGymInfo;
+  combatToken: string;
+}
+
+interface iCombatViewProps {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  _navigation?: NavigationProp<any, any>;
+  route: RouteProp<{ params: iCombatViewParams }, 'params'>;
+}
+
+export const CombatView = ({ _navigation, route }: iCombatViewProps) => {
+
+  // web socket
+  const url = `${WS_URL}/combat?token=${route.params.combatToken}`;
+  const { sendMessage, lastMessage, readyState } = useWebSocket(url);
+
+  // state
+  const [loomiePlayer, setLoomiePlayer] = useState<iLoomie>();
+  const [loomieGym, setLoomieGym] = useState<iLoomie>();
+
+  useEffect(() => {
+    // make sure we have workable parameters
+    if (!route.params.gym || !route.params.combatToken) navigate('Map');
+    console.log(url);
+  }, []);
+
+  // receive message
+
+  useEffect(() => {
+
+    if (!lastMessage?.data) return;
+
+    // cast check
+
+    let rawData: object = {};
+
+    try {
+      rawData = JSON.parse(lastMessage?.data);
+    } catch (error) {
+      console.log(error);
+      return;
+    }
+
+    // get object
+
+    if ((rawData as iCombatMessage) === undefined) return;
+    const data = rawData as iCombatMessage;
+    console.log(data.type);
+    console.log(data.payload);
+
+    const messageType = data.type as keyof typeof TYPE;
+    switch (TYPE[messageType]) {
+
+      case TYPE.start:{
+
+        if ((data.payload as iPayload_START) === undefined) return;
+        const payload = data.payload as iPayload_START;
+
+        console.log("start start start");
+        console.log(payload.gym);
+
+        setLoomieGym(payload.gym);
+        setLoomiePlayer(payload.player);
+      }
+      break;
+
+      case TYPE.UPDATE_USER_LOOMIE_HP:{
+        if ((data.payload as iPayload_UPDATE_USER_LOOMIE_HP) === undefined) return;
+        const payload = data.payload as iPayload_UPDATE_USER_LOOMIE_HP;
+
+        console.log(payload.hp);
+
+        setLoomiePlayer((loomie) => {
+          if (loomie) loomie.hp = payload.hp;
+          return loomie;
+        });
+      }
+      break;
+
+      default:
+        console.log(`Warn: Message not recognized ${data.type}`);
+        break;
+    }
+
+  }, [lastMessage]);
+
+  const attack = () => {
+  }
+
+
+
+  return (
+    <>
+
+      {/* 3D scene */}
+
+      <SafeAreaView style={{ flex: 1, backgroundColor: 'black' }}>
+        <View style={{ flex: 1 }}>
+          <Text>3D SCENE HERE</Text>
+          {/*getCurrentScene() == APP_SCENE.CAPTURE && (
+            <EngineView camera={cameraCapture} displayFrameRate={MAP_DEBUG} />
+          )*/}
+        </View>
+      </SafeAreaView>
+
+      {/* UI */}
+
+      <CombatUI gym={route.params.gym} loomiePlayer={loomiePlayer} loomieGym={loomieGym}/>
+
+      <Text>{route.params.gym.name}</Text>
+    </>
+  );
+  //return <Text >Hel</Text>;
 };

--- a/src/pages/CombatView.tsx
+++ b/src/pages/CombatView.tsx
@@ -15,7 +15,8 @@ import {
   TYPE,
   iPayload_UPDATE_PLAYER_LOOMIE,
   iPayload_GYM_LOOMIE_WEAKENED,
-  iPayload_USER_LOOMIE_WEAKENED
+  iPayload_USER_LOOMIE_WEAKENED,
+  iPayload_USER_ITEM_USED
 } from '@src/types/combatInterfaces';
 import { useToastAlert } from '@src/hooks/useToastAlert';
 import { delay } from '@src/utils/delay';
@@ -295,6 +296,38 @@ export const CombatView = ({ _navigation, route }: iCombatViewProps) => {
           modalCloseAll();
           modalLooseToggle(true);
           queueMessage('You have lost', false);
+        }
+        break;
+
+      // use item
+
+      case TYPE.USER_ITEM_USED:
+        {
+          if ((data.payload as iPayload_USER_ITEM_USED) === undefined) return;
+          const payload = data.payload as iPayload_USER_ITEM_USED;
+          let message = '';
+
+          switch (payload.item_serial) {
+            case 1:
+            case 2:
+            case 3: // health items
+              message = `Loomie healed`;
+              break;
+            case 4: // defibrillator
+              message = 'Loomie revived!';
+              break;
+            case 5: // steroids
+              message = `Attack boosted`;
+              break;
+            case 6: // vitamins
+              message = `Max health boosted`;
+              break;
+            case 7: // uknown beverage
+              message = `Level up`;
+              break;
+          }
+
+          queueMessage(message, false);
         }
         break;
 

--- a/src/pages/UserInventory.tsx
+++ b/src/pages/UserInventory.tsx
@@ -24,8 +24,8 @@ export const UserInventory = ({ navigation }: IProps) => {
   };
 
   const getInventory = async () => {
-    const [response, error] = await getItemsService();
-    if (error) return;
+    const response = await getItemsService();
+    if (!response) return;
     setItems(response.items);
     setLoomballs(response.loomballs);
     setLoading(false);

--- a/src/services/combat.services.ts
+++ b/src/services/combat.services.ts
@@ -7,15 +7,17 @@ import { CONFIG } from './config.services';
 const { API_URL } = CONFIG;
 
 // Register a combat
+// If successfull returns the payload
+// Otherwise return null and an error code
 
 export const requestCombatRegister = async (
   userPos: iPosition,
   gymId: string,
   failed = false
-): Promise<iRequestCombatRegister | null> => {
+): Promise<[iRequestCombatRegister | null, number]> => {
   try {
     const [accessToken, error] = await getStorageData('accessToken');
-    if (error || !accessToken) return null;
+    if (error || !accessToken) return [null, 0];
 
     const response = await Axios.post(
       `${API_URL}/combat/register`,
@@ -34,11 +36,11 @@ export const requestCombatRegister = async (
     // cast check
     const rawData: object = response.data;
     if ((rawData as iRequestCombatRegister) === undefined) {
-      return null;
+      return [null, 0];
     }
 
     const data: iRequestCombatRegister = rawData as iRequestCombatRegister;
-    return data;
+    return [data, 0];
   } catch (err) {
     console.error(err);
 
@@ -48,9 +50,9 @@ export const requestCombatRegister = async (
     }
 
     if (Axios.isAxiosError(err)) {
-      return null;
+      return [null, err.response?.status ? err.response?.status : 0];
     }
 
-    return null;
+    return [null, 0];
   }
 };

--- a/src/services/combat.services.ts
+++ b/src/services/combat.services.ts
@@ -14,10 +14,10 @@ export const requestCombatRegister = async (
   userPos: iPosition,
   gymId: string,
   failed = false
-): Promise<[iRequestCombatRegister | null, number]> => {
+): Promise<[iRequestCombatRegister | null, string]> => {
   try {
     const [accessToken, error] = await getStorageData('accessToken');
-    if (error || !accessToken) return [null, 0];
+    if (error || !accessToken) return [null, ''];
 
     const response = await Axios.post(
       `${API_URL}/combat/register`,
@@ -36,23 +36,26 @@ export const requestCombatRegister = async (
     // cast check
     const rawData: object = response.data;
     if ((rawData as iRequestCombatRegister) === undefined) {
-      return [null, 0];
+      return [null, ''];
     }
 
     const data: iRequestCombatRegister = rawData as iRequestCombatRegister;
-    return [data, 0];
+    return [data, ''];
   } catch (err) {
-    console.error(err);
-
     if (Axios.isAxiosError(err) && err.response?.status === 401 && !failed) {
       await refreshRequest();
       return await requestCombatRegister(userPos, gymId, true);
     }
 
     if (Axios.isAxiosError(err)) {
-      return [null, err.response?.status ? err.response?.status : 0];
+      return [
+        null,
+        err.response?.data.message
+          ? err.response.data.message
+          : 'Please try again later'
+      ];
     }
 
-    return [null, 0];
+    return [null, ''];
   }
 };

--- a/src/services/combat.services.ts
+++ b/src/services/combat.services.ts
@@ -1,0 +1,56 @@
+import Axios from 'axios';
+import { refreshRequest } from './session.services';
+import { getStorageData } from './storage.services';
+import { iPosition } from '@src/types/mapInterfaces';
+import { iRequestCombatRegister } from '@src/types/requestInterfaces';
+import { CONFIG } from './config.services';
+const { API_URL } = CONFIG;
+
+// Register a combat
+
+export const requestCombatRegister = async (
+  userPos: iPosition,
+  gymId: string,
+  failed = false
+): Promise<iRequestCombatRegister | null> => {
+  try {
+    const [accessToken, error] = await getStorageData('accessToken');
+    if (error || !accessToken) return null;
+
+    const response = await Axios.post(
+      `${API_URL}/combat/register`,
+      {
+        gym_id: gymId,
+        latitude: userPos.lat,
+        longitude: userPos.lon
+      },
+      {
+        headers: {
+          'Access-Token': accessToken
+        }
+      }
+    );
+
+    // cast check
+    const rawData: object = response.data;
+    if ((rawData as iRequestCombatRegister) === undefined) {
+      return null;
+    }
+
+    const data: iRequestCombatRegister = rawData as iRequestCombatRegister;
+    return data;
+  } catch (err) {
+    console.error(err);
+
+    if (Axios.isAxiosError(err) && err.response?.status === 401 && !failed) {
+      await refreshRequest();
+      return await requestCombatRegister(userPos, gymId, true);
+    }
+
+    if (Axios.isAxiosError(err)) {
+      return null;
+    }
+
+    return null;
+  }
+};

--- a/src/services/config.services.ts
+++ b/src/services/config.services.ts
@@ -1,7 +1,14 @@
 import Config from 'react-native-config';
 
+const TSL = Config.TSL == 'true';
+
 export const CONFIG = {
-  API_URL: Config.API_URL,
+  API_URL: TSL
+    ? `https://${Config.API_URL}:${Config.PORT}`
+    : `http://${Config.API_URL}:${Config.PORT}`,
+  WS_URL: TSL
+    ? `wss://${Config.API_URL}:${Config.PORT}`
+    : `ws://${Config.API_URL}:${Config.PORT}`,
   MAP_DEBUG: Config.MAP_DEBUG == 'true',
   GAME_MIN_REQUIRED_EXPERIENCE: Config.GAME_MIN_REQUIRED_EXPERIENCE,
   GAME_EXPERIENCE_FACTOR: Config.GAME_EXPERIENCE_FACTOR,

--- a/src/services/user.services.ts
+++ b/src/services/user.services.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import { iRequestUserItems } from '@src/types/requestInterfaces';
 import { TLoomball } from '@src/types/types';
 import Axios from 'axios';
 import { CONFIG } from './config.services';
@@ -135,10 +136,10 @@ export const newCodeRequest = async (
 
 export const getItemsService = async (
   callNumber = 1
-): Promise<[any, boolean]> => {
+): Promise<iRequestUserItems | null> => {
   try {
     const [accessToken, error] = await getStorageData('accessToken');
-    if (error || !accessToken) return [null, true];
+    if (error || !accessToken) return null;
 
     const response = await Axios.get(`${API_URL}/user/items`, {
       headers: {
@@ -146,7 +147,15 @@ export const getItemsService = async (
       }
     });
 
-    return [response.data, false];
+    // cast check
+    const rawData: object = response.data;
+    if ((rawData as iRequestUserItems) === undefined) {
+      throw 'Error: getItemsService cast error';
+    }
+
+    // return items
+    const items: iRequestUserItems = rawData as iRequestUserItems;
+    return items;
   } catch (err) {
     if (
       Axios.isAxiosError(err) &&
@@ -158,10 +167,10 @@ export const getItemsService = async (
     }
 
     if (Axios.isAxiosError(err)) {
-      return [err.response?.data, true];
+      return null;
     }
 
-    return [null, true];
+    return null;
   }
 };
 

--- a/src/services/user.services.ts
+++ b/src/services/user.services.ts
@@ -179,19 +179,9 @@ export const getItemsService = async (
 
 export const getLoomballsService = async (): Promise<TLoomball[]> => {
   try {
-    const [items, err] = await getItemsService();
-    if (err) throw err;
-
-    // cast check
-    const rawData: object = items['loomballs'];
-    if ((rawData as TLoomball[]) === undefined) {
-      throw 'Error: getLoomballsService cast error';
-    }
-
-    // return loomballs available to player
-    const loomballs: TLoomball[] = rawData as TLoomball[];
-
-    return loomballs;
+    const data = await getItemsService();
+    if (!data) throw 'Error: getLoomballsService when getting items';
+    return data.loomballs;
   } catch (e) {
     console.error(e);
   }

--- a/src/types/combatInterfaces.ts
+++ b/src/types/combatInterfaces.ts
@@ -50,7 +50,8 @@ export interface iCombatMessage {
     | iPayload_UPDATE_PLAYER_LOOMIE
     | iPayload_GYM_LOOMIE_WEAKENED
     | iPayload_USER_LOOMIE_WEAKENED
-    | iPayload_USER_ITEM_USED;
+    | iPayload_USER_ITEM_USED
+    | iPayload_ERROR_USING_ITEM;
 }
 
 export interface iPayload_START {
@@ -85,6 +86,12 @@ export interface iPayload_USER_ITEM_USED {
   item_id: string;
   item_serial: number;
   item_name: string;
+}
+
+export interface iPayload_ERROR_USING_ITEM {
+  error_reason: string;
+  item_id: string;
+  item_serial: number;
 }
 
 export interface iLoomie {

--- a/src/types/combatInterfaces.ts
+++ b/src/types/combatInterfaces.ts
@@ -1,3 +1,14 @@
+// state
+
+export enum COMBAT_STATE {
+  NONE,
+  PLAYING,
+  LOST,
+  WON
+}
+
+// messages
+
 export enum TYPE {
   // server -> client
 

--- a/src/types/combatInterfaces.ts
+++ b/src/types/combatInterfaces.ts
@@ -46,6 +46,8 @@ export interface iPayload_START {
 export interface iPayload_UPDATE_USER_LOOMIE_HP {
   hp: number;
   loomie_id: string;
+  damage: number;
+  was_critical: boolean;
 }
 
 export interface iPayload_UPDATE_PLAYER_LOOMIE {

--- a/src/types/combatInterfaces.ts
+++ b/src/types/combatInterfaces.ts
@@ -1,24 +1,38 @@
 export enum TYPE {
+  // server -> client
+
   start,
+  UPDATE_PLAYER_LOOMIE,
+  UPDATE_USER_LOOMIE_HP,
+  UPDATE_GYM_LOOMIE,
+  UPDATE_GYM_LOOMIE_HP,
+
   ERROR,
   COMBAT_TIMEOUT,
   GYM_ATTACK_CANDIDATE,
   GYM_ATTACK_DODGED,
   USER_LOOMIE_WEAKENED,
-  UPDATE_PLAYER_LOOMIE,
-  UPDATE_USER_LOOMIE_HP,
   USER_HAS_LOST,
   USER_ATTACK_DODGED,
   GYM_LOOMIE_WEAKENED,
-  UPDATE_GYM_LOOMIE,
-  UPDATE_GYM_LOOMIE_HP,
-  USER_HAS_WON
+  USER_HAS_WON,
+
+
+  // client -> server
+
+  USER_USE_ITEM,
+  USER_CHANGE_LOOMIE,
+  USER_DODGE,
+  USER_ATTACK
 }
 
 export interface iCombatMessage {
   type: string;
   message: string;
-  payload?: iPayload_START | iPayload_UPDATE_USER_LOOMIE_HP;
+  payload?:
+    | iPayload_START
+    | iPayload_UPDATE_USER_LOOMIE_HP
+    | iPayload_UPDATE_PLAYER_LOOMIE;
 }
 
 export interface iPayload_START {
@@ -47,4 +61,8 @@ export interface iLoomie {
 export interface iPayload_UPDATE_USER_LOOMIE_HP {
   hp: number;
   loomie_id: string;
+}
+
+export interface iPayload_UPDATE_PLAYER_LOOMIE {
+  loomie: iLoomie;
 }

--- a/src/types/combatInterfaces.ts
+++ b/src/types/combatInterfaces.ts
@@ -16,13 +16,15 @@ export enum TYPE {
   USER_ATTACK_DODGED,
   GYM_LOOMIE_WEAKENED,
   USER_HAS_WON,
+  ESCAPE_COMBAT,
 
   // client -> server
 
   USER_USE_ITEM,
   USER_CHANGE_LOOMIE,
   USER_DODGE,
-  USER_ATTACK
+  USER_ATTACK,
+  USER_ESCAPE_COMBAT
 }
 
 export interface iCombatMessage {

--- a/src/types/combatInterfaces.ts
+++ b/src/types/combatInterfaces.ts
@@ -31,12 +31,16 @@ export interface iCombatMessage {
   payload?:
     | iPayload_START
     | iPayload_UPDATE_USER_LOOMIE_HP
-    | iPayload_UPDATE_PLAYER_LOOMIE;
+    | iPayload_UPDATE_PLAYER_LOOMIE
+    | iPayload_GYM_LOOMIE_WEAKENED
+    | iPayload_USER_LOOMIE_WEAKENED;
 }
 
 export interface iPayload_START {
-  gym: iLoomie;
-  player: iLoomie;
+  alive_gym_loomies: number;
+  alive_user_loomies: number;
+  gym_loomie: iLoomie;
+  player_loomie: iLoomie;
 }
 
 export interface iPayload_UPDATE_USER_LOOMIE_HP {
@@ -46,6 +50,16 @@ export interface iPayload_UPDATE_USER_LOOMIE_HP {
 
 export interface iPayload_UPDATE_PLAYER_LOOMIE {
   loomie: iLoomie;
+}
+
+export interface iPayload_USER_LOOMIE_WEAKENED {
+  alive_user_loomies: number;
+  loomie_id: string;
+}
+
+export interface iPayload_GYM_LOOMIE_WEAKENED {
+  alive_gym_loomies: number;
+  loomie_id: string;
 }
 
 export interface iLoomie {

--- a/src/types/combatInterfaces.ts
+++ b/src/types/combatInterfaces.ts
@@ -1,0 +1,50 @@
+export enum TYPE {
+  start,
+  ERROR,
+  COMBAT_TIMEOUT,
+  GYM_ATTACK_CANDIDATE,
+  GYM_ATTACK_DODGED,
+  USER_LOOMIE_WEAKENED,
+  UPDATE_PLAYER_LOOMIE,
+  UPDATE_USER_LOOMIE_HP,
+  USER_HAS_LOST,
+  USER_ATTACK_DODGED,
+  GYM_LOOMIE_WEAKENED,
+  UPDATE_GYM_LOOMIE,
+  UPDATE_GYM_LOOMIE_HP,
+  USER_HAS_WON
+}
+
+export interface iCombatMessage {
+  type: string;
+  message: string;
+  payload?: iPayload_START | iPayload_UPDATE_USER_LOOMIE_HP;
+}
+
+export interface iPayload_START {
+  gym: iLoomie;
+  player: iLoomie;
+}
+
+export interface iLoomie {
+  _id: string;
+  attack: number;
+  boosted_attack: number;
+  boosted_defense: number;
+  boosted_hp: number;
+  defense: number;
+  experience: number;
+  hp: number;
+  is_busy: boolean;
+  level: number;
+  max_hp: number;
+  name: string;
+  rarity: string;
+  serial: number;
+  types: string[];
+}
+
+export interface iPayload_UPDATE_USER_LOOMIE_HP {
+  hp: number;
+  loomie_id: string;
+}

--- a/src/types/combatInterfaces.ts
+++ b/src/types/combatInterfaces.ts
@@ -85,7 +85,6 @@ export interface iPayload_GYM_LOOMIE_WEAKENED {
 export interface iPayload_USER_ITEM_USED {
   item_id: string;
   item_serial: number;
-  item_name: string;
 }
 
 export interface iPayload_ERROR_USING_ITEM {

--- a/src/types/combatInterfaces.ts
+++ b/src/types/combatInterfaces.ts
@@ -22,12 +22,15 @@ export enum TYPE {
   COMBAT_TIMEOUT,
   GYM_ATTACK_CANDIDATE,
   GYM_ATTACK_DODGED,
-  USER_LOOMIE_WEAKENED,
-  USER_HAS_LOST,
   USER_ATTACK_DODGED,
+  USER_LOOMIE_WEAKENED,
   GYM_LOOMIE_WEAKENED,
+  USER_HAS_LOST,
   USER_HAS_WON,
   ESCAPE_COMBAT,
+
+  ERROR_USING_ITEM,
+  USER_ITEM_USED,
 
   // client -> server
 
@@ -46,7 +49,8 @@ export interface iCombatMessage {
     | iPayload_UPDATE_USER_LOOMIE_HP
     | iPayload_UPDATE_PLAYER_LOOMIE
     | iPayload_GYM_LOOMIE_WEAKENED
-    | iPayload_USER_LOOMIE_WEAKENED;
+    | iPayload_USER_LOOMIE_WEAKENED
+    | iPayload_USER_ITEM_USED;
 }
 
 export interface iPayload_START {
@@ -75,6 +79,12 @@ export interface iPayload_USER_LOOMIE_WEAKENED {
 export interface iPayload_GYM_LOOMIE_WEAKENED {
   alive_gym_loomies: number;
   loomie_id: string;
+}
+
+export interface iPayload_USER_ITEM_USED {
+  item_id: string;
+  item_serial: number;
+  item_name: string;
 }
 
 export interface iLoomie {

--- a/src/types/combatInterfaces.ts
+++ b/src/types/combatInterfaces.ts
@@ -17,7 +17,6 @@ export enum TYPE {
   GYM_LOOMIE_WEAKENED,
   USER_HAS_WON,
 
-
   // client -> server
 
   USER_USE_ITEM,
@@ -40,6 +39,15 @@ export interface iPayload_START {
   player: iLoomie;
 }
 
+export interface iPayload_UPDATE_USER_LOOMIE_HP {
+  hp: number;
+  loomie_id: string;
+}
+
+export interface iPayload_UPDATE_PLAYER_LOOMIE {
+  loomie: iLoomie;
+}
+
 export interface iLoomie {
   _id: string;
   attack: number;
@@ -56,13 +64,4 @@ export interface iLoomie {
   rarity: string;
   serial: number;
   types: string[];
-}
-
-export interface iPayload_UPDATE_USER_LOOMIE_HP {
-  hp: number;
-  loomie_id: string;
-}
-
-export interface iPayload_UPDATE_PLAYER_LOOMIE {
-  loomie: iLoomie;
 }

--- a/src/types/combatInterfaces.ts
+++ b/src/types/combatInterfaces.ts
@@ -13,7 +13,7 @@ export enum TYPE {
   // server -> client
 
   start,
-  UPDATE_PLAYER_LOOMIE,
+  UPDATE_USER_LOOMIE,
   UPDATE_USER_LOOMIE_HP,
   UPDATE_GYM_LOOMIE,
   UPDATE_GYM_LOOMIE_HP,

--- a/src/types/requestInterfaces.ts
+++ b/src/types/requestInterfaces.ts
@@ -1,4 +1,10 @@
-import { TWildLoomies, TGymInfo, TReward } from '@src/types/types';
+import {
+  TWildLoomies,
+  TGymInfo,
+  TReward,
+  TItem,
+  TLoomball
+} from '@src/types/types';
 
 export interface iRequestGym {
   _id: string;
@@ -47,4 +53,11 @@ export interface iRequestCombatRegister {
   error: boolean;
   message: string;
   combat_token: string;
+}
+
+export interface iRequestUserItems {
+  error: boolean;
+  message: string;
+  items: TItem[];
+  loomballs: TLoomball[];
 }

--- a/src/types/requestInterfaces.ts
+++ b/src/types/requestInterfaces.ts
@@ -39,6 +39,12 @@ export interface iRequestWildLoomieExists {
 
 export interface iRequestCaptureLoomieAttempt {
   error: boolean;
-  capture: boolean;
   message: string;
+  capture: boolean;
+}
+
+export interface iRequestCombatRegister {
+  error: boolean;
+  message: string;
+  combat_token: string;
 }

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -67,6 +67,7 @@ export interface TGymInfo {
   owner: string;
   protectors: TGymLoomieProtector[];
   was_reward_claimed: boolean;
+  user_owns_it: boolean;
 }
 
 // Shared interface between the items and the loomballs

--- a/src/utils/delay.ts
+++ b/src/utils/delay.ts
@@ -1,0 +1,7 @@
+/*
+ * Awaits a determined amount of milliseconds
+ */
+export const delay = (ms: number): Promise<void> =>
+  new Promise((resolve): void => {
+    setTimeout(resolve, ms);
+  });

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -20,7 +20,6 @@ export const colors: {
 export const images: {
   [key: string]: ImageSourcePropType;
 } = {
-
   // Loomies
 
   '001': require('@assets/images/loomies/001.png'),

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -20,7 +20,9 @@ export const colors: {
 export const images: {
   [key: string]: ImageSourcePropType;
 } = {
+
   // Loomies
+
   '001': require('@assets/images/loomies/001.png'),
   '002': require('@assets/images/loomies/002.png'),
   '003': require('@assets/images/loomies/003.png'),
@@ -40,7 +42,9 @@ export const images: {
   '017': require('@assets/images/loomies/017.png'),
   '018': require('@assets/images/loomies/018.png'),
   '019': require('@assets/images/loomies/019.png'),
+
   // Objects
+
   'O-001': require('@assets/images/items/001.png'),
   'O-002': require('@assets/images/items/002.png'),
   'O-003': require('@assets/images/items/003.png'),
@@ -51,7 +55,9 @@ export const images: {
   'O-008': require('@assets/images/items/008.png'),
   'O-009': require('@assets/images/items/009.png'),
   'O-010': require('@assets/images/items/010.png'),
+
   // UI
+
   'LOOMBALL': require('@assets/images/ui/loomball.png')
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6452,6 +6452,11 @@ react-test-renderer@18.0.0:
     react-shallow-renderer "^16.13.1"
     scheduler "^0.21.0"
 
+react-use-websocket@3:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/react-use-websocket/-/react-use-websocket-3.0.0.tgz#754cb8eea76f55d31c5676d4abe3e573bc2cea04"
+  integrity sha512-BInlbhXYrODBPKIplDAmI0J1VPM+1KhCLN09o+dzgQ8qMyrYs4t5kEYmCrTqyRuMTmpahylHFZWQXpfYyDkqOw==
+
 react@18.0.0:
   version "18.0.0"
   resolved "https://registry.yarnpkg.com/react/-/react-18.0.0.tgz#b468736d1f4a5891f38585ba8e8fb29f91c3cb96"


### PR DESCRIPTION
# What's new

## Combat UI

- Combat view featuring custom widgets for showing battle status.
- Cursor gizmo for attack, dodge inputs.
- Animated game messages.
- Show amount of available Loomies left in both user and gym team.
- A generic modal that receives: title, description, callback on ok, callback on cancel, ok button label, cancel button label.
- User defeated modal (With generic modal).
- User victory modal (With generic modal).
- User escape modal (With generic modal).
- Return to Map when failing to establish web socket connection.
- Hide the "Challenge" button when the user owns the gym.
- Show a warning toast when there are no Loomies on the team.

## Use items

- Modal for picking items.
- Custom messages when using an item.
- Custom messages when failing to use an item.
- **Note:** Modal for defibrillator currently not supported.

*I know this should've been a separated PR but since we are in a rush...*



## Notes

- This PR depends on https://github.com/PedroChaparro/loomies-backend/pull/120.
- Check your environment variables, some where modified. 

# Preview

|![image](https://user-images.githubusercontent.com/61242172/234119700-d4d92a4e-9fa6-406c-b4ab-342fd6a1d8d4.png)|![image](https://user-images.githubusercontent.com/61242172/234367279-9c4c32e4-e15b-40f6-8625-cf43b16c538f.png)|![image](https://user-images.githubusercontent.com/61242172/234367455-ea2de949-1c80-4703-b12e-fdd739f027e4.png)|![image](https://user-images.githubusercontent.com/61242172/234382634-7037e70b-3a5a-44f4-b3a1-f4e2698fa271.png)|
|---|---|---|---|
|Animated message indicating damage|Using an item while in combat|Escape and Win modals are similar|Can't attack a gym owned by yourself|






